### PR TITLE
Add public_ipv4_subnet_size option to packet_device, plus acceptance test

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -112,6 +112,12 @@ func resourcePacketDevice() *schema.Resource {
 				Optional: true,
 			},
 
+			"public_ipv4_subnet_size": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -125,12 +131,13 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*packngo.Client)
 
 	createRequest := &packngo.DeviceCreateRequest{
-		HostName:     d.Get("hostname").(string),
-		Plan:         d.Get("plan").(string),
-		Facility:     d.Get("facility").(string),
-		OS:           d.Get("operating_system").(string),
-		BillingCycle: d.Get("billing_cycle").(string),
-		ProjectID:    d.Get("project_id").(string),
+		HostName:             d.Get("hostname").(string),
+		Plan:                 d.Get("plan").(string),
+		Facility:             d.Get("facility").(string),
+		OS:                   d.Get("operating_system").(string),
+		BillingCycle:         d.Get("billing_cycle").(string),
+		ProjectID:            d.Get("project_id").(string),
+		PublicIPv4SubnetSize: d.Get("public_ipv4_subnet_size").(int),
 	}
 
 	if attr, ok := d.GetOk("user_data"); ok {

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -114,6 +114,7 @@ func resourcePacketDevice() *schema.Resource {
 
 			"public_ipv4_subnet_size": &schema.Schema{
 				Type:     schema.TypeInt,
+				Computed: true,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -208,8 +209,9 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("tags", tags)
 
 	var (
-		host     string
-		networks = make([]map[string]interface{}, 0, 1)
+		ipv4SubnetSize int
+		host           string
+		networks       = make([]map[string]interface{}, 0, 1)
 	)
 	for _, ip := range device.Network {
 		network := map[string]interface{}{
@@ -223,9 +225,11 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 
 		if ip.AddressFamily == 4 && ip.Public == true {
 			host = ip.Address
+			ipv4SubnetSize = ip.Cidr
 		}
 	}
 	d.Set("network", networks)
+	d.Set("public_ipv4_subnet_size", ipv4SubnetSize)
 
 	if host != "" {
 		d.SetConnInfo(map[string]string{

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -1,0 +1,156 @@
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/packethost/packngo"
+)
+
+func TestAccPacketDevice_Basic(t *testing.T) {
+	var device packngo.Device
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketDeviceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckPacketDeviceConfig_basic, rs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketDeviceExists("packet_device.terraform_test_device", &device),
+					testAccCheckPacketDeviceAttributes(&device),
+					testAccCheckPacketDevicePublicIPv4Cidr(&device, 31),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPacketDevice_RequestSubnet(t *testing.T) {
+	var device packngo.Device
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketDeviceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckPacketDeviceConfig_request_subnet, rs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketDeviceExists("packet_device.terraform_test_device_subnet_29", &device),
+					testAccCheckPacketDevicePublicIPv4Cidr(&device, 29),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPacketDeviceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*packngo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "packet_device" {
+			continue
+		}
+		if _, _, err := client.Devices.Get(rs.Primary.ID); err == nil {
+			return fmt.Errorf("Device still exists")
+		}
+	}
+	return nil
+}
+
+func getPublicIPv4Cidr(device *packngo.Device) (int, error) {
+	for _, ipa := range device.Network {
+		if ipa.AddressFamily == 4 && ipa.Public {
+			return ipa.Cidr, nil
+		}
+	}
+	return 0, fmt.Errorf("device %s does not have a public IPv4", device.ID)
+}
+
+func testAccCheckPacketDevicePublicIPv4Cidr(device *packngo.Device, cidr int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		devCidr, err := getPublicIPv4Cidr(device)
+		if err != nil {
+			return err
+		}
+		if devCidr != cidr {
+			return fmt.Errorf("The CIDR prefix of device %s is %d, but is %d instead", device.ID, devCidr, cidr)
+		}
+		return nil
+	}
+}
+
+func testAccCheckPacketDeviceAttributes(device *packngo.Device) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if device.Hostname != "terraform-test-device" {
+			return fmt.Errorf("Bad name: %s", device.Hostname)
+		}
+		if device.State != "active" {
+			return fmt.Errorf("Device should be 'active', not '%s'", device.State)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckPacketDeviceExists(n string, device *packngo.Device) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*packngo.Client)
+
+		foundDevice, _, err := client.Devices.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if foundDevice.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found: %v - %v", rs.Primary.ID, foundDevice)
+		}
+
+		*device = *foundDevice
+
+		return nil
+	}
+}
+
+var testAccCheckPacketDeviceConfig_basic = `
+resource "packet_project" "terraform_test_project" {
+    name = "TerraformTestProject-%s"
+}
+
+resource "packet_device" "terraform_test_device" {
+  hostname         = "terraform-test-device"
+  plan             = "baremetal_0"
+  facility         = "sjc1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.terraform_test_project.id}"
+}`
+
+var testAccCheckPacketDeviceConfig_request_subnet = `
+resource "packet_project" "terraform_test_project" {
+    name = "TerraformTestProject-%s"
+}
+
+resource "packet_device" "terraform_test_device_subnet_29" {
+  hostname         = "terraform-test-device-subnet-29"
+  plan             = "baremetal_0"
+  facility         = "sjc1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.terraform_test_project.id}"
+  public_ipv4_subnet_size = 29
+}`

--- a/vendor/github.com/packethost/packngo/devices.go
+++ b/vendor/github.com/packethost/packngo/devices.go
@@ -23,21 +23,23 @@ type devicesRoot struct {
 
 // Device represents a Packet device
 type Device struct {
-	ID           string       `json:"id"`
-	Href         string       `json:"href,omitempty"`
-	Hostname     string       `json:"hostname,omitempty"`
-	State        string       `json:"state,omitempty"`
-	Created      string       `json:"created_at,omitempty"`
-	Updated      string       `json:"updated_at,omitempty"`
-	Locked       bool         `json:"locked,omitempty"`
-	BillingCycle string       `json:"billing_cycle,omitempty"`
-	Tags         []string     `json:"tags,omitempty"`
-	Network      []*IPAddress `json:"ip_addresses"`
-	OS           *OS          `json:"operating_system,omitempty"`
-	Plan         *Plan        `json:"plan,omitempty"`
-	Facility     *Facility    `json:"facility,omitempty"`
-	Project      *Project     `json:"project,omitempty"`
-	ProvisionPer float32      `json:"provisioning_percentage,omitempty"`
+	ID            string       `json:"id"`
+	Href          string       `json:"href,omitempty"`
+	Hostname      string       `json:"hostname,omitempty"`
+	State         string       `json:"state,omitempty"`
+	Created       string       `json:"created_at,omitempty"`
+	Updated       string       `json:"updated_at,omitempty"`
+	Locked        bool         `json:"locked,omitempty"`
+	BillingCycle  string       `json:"billing_cycle,omitempty"`
+	Tags          []string     `json:"tags,omitempty"`
+	Network       []*IPAddress `json:"ip_addresses"`
+	OS            *OS          `json:"operating_system,omitempty"`
+	Plan          *Plan        `json:"plan,omitempty"`
+	Facility      *Facility    `json:"facility,omitempty"`
+	Project       *Project     `json:"project,omitempty"`
+	ProvisionPer  float32      `json:"provisioning_percentage,omitempty"`
+	IPXEScriptUrl string       `json:"ipxe_script_url,omitempty"`
+	AlwaysPXE     bool         `json:"always_pxe,omitempty"`
 }
 
 func (d Device) String() string {
@@ -46,14 +48,17 @@ func (d Device) String() string {
 
 // DeviceCreateRequest type used to create a Packet device
 type DeviceCreateRequest struct {
-	HostName     string   `json:"hostname"`
-	Plan         string   `json:"plan"`
-	Facility     string   `json:"facility"`
-	OS           string   `json:"operating_system"`
-	BillingCycle string   `json:"billing_cycle"`
-	ProjectID    string   `json:"project_id"`
-	UserData     string   `json:"userdata"`
-	Tags         []string `json:"tags"`
+	HostName             string   `json:"hostname"`
+	Plan                 string   `json:"plan"`
+	Facility             string   `json:"facility"`
+	OS                   string   `json:"operating_system"`
+	BillingCycle         string   `json:"billing_cycle"`
+	ProjectID            string   `json:"project_id"`
+	UserData             string   `json:"userdata"`
+	Tags                 []string `json:"tags"`
+	IPXEScriptUrl        string   `json:"ipxe_script_url,omitempty"`
+	PublicIPv4SubnetSize int      `json:"public_ipv4_subnet_size,omitempty"`
+	AlwaysPXE            bool     `json:"always_pxe,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {

--- a/vendor/github.com/packethost/packngo/ip.go
+++ b/vendor/github.com/packethost/packngo/ip.go
@@ -25,6 +25,7 @@ type IPAddress struct {
 	Created       string            `json:"created_at,omitempty"`
 	Updated       string            `json:"updated_at,omitempty"`
 	Href          string            `json:"href"`
+	Facility      Facility          `json:"facility,omitempty"`
 }
 
 // IPAddressAssignRequest represents the body if a ip assign request

--- a/vendor/github.com/packethost/packngo/sshkeys.go
+++ b/vendor/github.com/packethost/packngo/sshkeys.go
@@ -35,8 +35,9 @@ func (s SSHKey) String() string {
 
 // SSHKeyCreateRequest type used to create an ssh key
 type SSHKeyCreateRequest struct {
-	Label string `json:"label"`
-	Key   string `json:"key"`
+	Label     string `json:"label"`
+	Key       string `json:"key"`
+	ProjectID string `json:"-"`
 }
 
 func (s SSHKeyCreateRequest) String() string {
@@ -95,7 +96,11 @@ func (s *SSHKeyServiceOp) Get(sshKeyID string) (*SSHKey, *Response, error) {
 
 // Create creates a new ssh key
 func (s *SSHKeyServiceOp) Create(createRequest *SSHKeyCreateRequest) (*SSHKey, *Response, error) {
-	req, err := s.client.NewRequest("POST", sshKeyBasePath, createRequest)
+	path := sshKeyBasePath
+	if createRequest.ProjectID != "" {
+		path = "/projects/" + createRequest.ProjectID + sshKeyBasePath
+	}
+	req, err := s.client.NewRequest("POST", path, createRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -552,10 +552,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "MexE5QPVAwVfQcJBnMGMgD+s9L0=",
+			"checksumSHA1": "jkFIm/vAhCIQmbPI4hLCG4sr/9s=",
 			"path": "github.com/packethost/packngo",
-			"revision": "7cd5fed006859e86dd5641a6cf9812e855b7574a",
-			"revisionTime": "2016-08-11T16:27:25Z"
+			"revision": "9d9409c8c09de7695281e900a776cca03676026a",
+			"revisionTime": "2017-08-14T13:23:19Z"
 		},
 		{
 			"checksumSHA1": "u5s2PZ7fzCOqQX7bVPf9IJ+qNLQ=",

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `plan` - (Required) The hardware config slug
 * `billing_cycle` - (Required) monthly or hourly
 * `user_data` (Optional) - A string of the desired User Data for the device.
+* `public_ipv4_subnet_size` (Optional) - Size of allocated subnet, more info in [guide doc](https://help.packet.net/technical/networking/custom-subnet-size).
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds the options `public_ipv4_subnet_size` to the packet_device resource. The make it possible to allocate IPv4 subnet on device creation. More on this at
https://help.packet.net/technical/networking/custom-subnet-size

We had a user request for this.  

I had to update the packngo version.

I also wrote an acceptance test for the packet_device module. It takes several minutes, as the device provisioning takes a while.

I am open for comments and suggestions to improve this.