### PR TITLE
Set device user_data field to Sensitive

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -108,8 +108,9 @@ func resourcePacketDevice() *schema.Resource {
 			},
 
 			"user_data": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 
 			"public_ipv4_subnet_size": &schema.Schema{


### PR DESCRIPTION
This causes user_data to be omitted from log/console output.

Fixes #12 