### PR TITLE
Add hardware_reservation_id field to the packet_device resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 * resource/packet_device: Add `public_ipv4_subnet_size` field [GH-7]
+* resource/packet_device: Add `hardware_reservation_id` field [GH-7]
 
 ## 0.1.0 (June 21, 2017)
 

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -3,6 +3,7 @@ package packet
 import (
 	"errors"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -131,6 +132,12 @@ func resourcePacketDevice() *schema.Resource {
 				Default:  false,
 			},
 
+			"hardware_reservation_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -159,6 +166,10 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if attr, ok := d.GetOk("ipxe_script_url"); ok {
 		createRequest.IPXEScriptURL = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("hardware_reservation_id"); ok {
+		createRequest.HardwareReservationID = attr.(string)
 	}
 
 	if createRequest.OS == "custom_ipxe" && createRequest.IPXEScriptURL == "" {
@@ -233,6 +244,10 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("updated", device.Updated)
 	d.Set("ipxe_script_url", device.IPXEScriptURL)
 	d.Set("always_pxe", device.AlwaysPXE)
+
+	if len(device.HardwareReservation.Href) > 0 {
+		d.Set("hardware_reservation_id", path.Base(device.HardwareReservation.Href))
+	}
 
 	tags := make([]string, 0, len(device.Tags))
 	for _, tag := range device.Tags {

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
   doc.
 * `always_pxe` (Optional) - If true, a device with OS `custom_ipxe` will
   continue to boot via iPXE on reboots.
+* `hardware_reservation_id` (Optional) - The id of hardware reservation where you want this device deployed
 
 ## Attributes Reference
 
@@ -78,3 +79,4 @@ The following attributes are exported:
 * `created` - The timestamp for when the device was created
 * `updated` - The timestamp for the last time the device was updated
 * `tags` - Tags attached to the device
+* `hardware_reservation_id` - The id of hardware reservation which this device occupies


### PR DESCRIPTION
This PR adds hw reservation field to the packet_device resource. This makes it possible to utilize customer's reserved hardware in Packet host with Terraform. More info at
https://help.packet.net/technical/deployment-options/reserved-hardware
