### PR TITLE
Fix over-reaching user_data/ipxe_script_url conflict

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -143,9 +143,8 @@ func resourcePacketDevice() *schema.Resource {
 			},
 
 			"ipxe_script_url": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				ConflictsWith: []string{"user_data"},
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"always_pxe": &schema.Schema{

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/packethost/packngo"
 )
+
+var matchIPXEScript = regexp.MustCompile(`(?i)^#![i]?pxe`)
 
 func resourcePacketDevice() *schema.Resource {
 	return &schema.Resource{
@@ -204,6 +207,15 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 		if createRequest.IPXEScriptURL == "" && createRequest.UserData == "" {
 			return friendlyError(errors.New("\"ipxe_script_url\" or \"user_data\"" +
 				" must be provided when \"custom_ipxe\" OS is selected."))
+		}
+
+		// ipxe_script_url + user_data is OK, unless user_data is an ipxe script in
+		// which case it's an error.
+		if createRequest.IPXEScriptURL != "" {
+			if matchIPXEScript.MatchString(createRequest.UserData) {
+				return friendlyError(errors.New("\"user_data\" should not be an iPXE " +
+					"script when \"ipxe_script_url\" is also provided."))
+			}
 		}
 	}
 

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 // Regexp vars for use with resource.ExpectError
-var matchErrConflictsWith = regexp.MustCompile(".* conflicts with .*")
 var matchErrMustBeProvided = regexp.MustCompile(".* must be provided when .*")
+var matchErrShouldNotBeAnIPXE = regexp.MustCompile(`.*"user_data" should not be an iPXE.*`)
 
 func TestAccPacketDevice_Basic(t *testing.T) {
 	var device packngo.Device
@@ -86,27 +86,6 @@ func TestAccPacketDevice_IPXEScriptUrl(t *testing.T) {
 					testAccCheckPacketDeviceNetwork(r),
 					resource.TestCheckResourceAttr(
 						r, "ipxe_script_url", "https://boot.netboot.xyz"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccPacketDevice_AlwaysPXE(t *testing.T) {
-	var device packngo.Device
-	rs := acctest.RandString(10)
-	r := "packet_device.test_always_pxe"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPacketDeviceDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: fmt.Sprintf(testAccCheckPacketDeviceConfig_always_pxe, rs),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPacketDeviceExists(r, &device),
-					testAccCheckPacketDeviceNetwork(r),
 					resource.TestCheckResourceAttr(
 						r, "always_pxe", "true"),
 				),
@@ -115,7 +94,7 @@ func TestAccPacketDevice_AlwaysPXE(t *testing.T) {
 	})
 }
 
-func TestAccPacketDevice_ConflictingFields(t *testing.T) {
+func TestAccPacketDevice_IPXEConflictingFields(t *testing.T) {
 	var device packngo.Device
 	rs := acctest.RandString(10)
 	r := "packet_device.test_ipxe_conflict"
@@ -130,7 +109,7 @@ func TestAccPacketDevice_ConflictingFields(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketDeviceExists(r, &device),
 				),
-				ExpectError: matchErrConflictsWith,
+				ExpectError: matchErrShouldNotBeAnIPXE,
 			},
 		},
 	})
@@ -149,8 +128,6 @@ func TestAccPacketDevice_IPXEConfigMissing(t *testing.T) {
 			resource.TestStep{
 				Config: fmt.Sprintf(testAccCheckPacketDeviceConfig_ipxe_missing, rs),
 				Check: resource.ComposeTestCheckFunc(
-					// resource.TestCheckNoResourceAttr("r", "user_data"),
-					// resource.TestCheckNoResourceAttr("r", "ipxe_script_url"),
 					testAccCheckPacketDeviceExists(r, &device),
 				),
 				ExpectError: matchErrMustBeProvided,
@@ -288,21 +265,7 @@ resource "packet_device" "test_ipxe_script_url" {
   plan             = "baremetal_0"
   facility         = "sjc1"
   operating_system = "custom_ipxe"
-  billing_cycle    = "hourly"
-  project_id       = "${packet_project.test.id}"
-  ipxe_script_url  = "https://boot.netboot.xyz"
-}`
-
-var testAccCheckPacketDeviceConfig_always_pxe = `
-resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
-}
-
-resource "packet_device" "test_always_pxe" {
-  hostname         = "test-always-pxe"
-  plan             = "baremetal_0"
-  facility         = "sjc1"
-  operating_system = "custom_ipxe"
+  user_data        = "#!/bin/sh\ntouch /tmp/test"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
   ipxe_script_url  = "https://boot.netboot.xyz"


### PR DESCRIPTION
Fixes #22 

TODO:
- [x] Remove blanket conflict between `ipxe_script_url` set + `user_data`
- [x] Error on `ipxe_script_url` set + `user_data` begins with `#!ipxe`
- [x] Add test to verify both scenarios: conflict (done) and no conflict