### PR TITLE
provider: Add logging transport for HTTP client

### DIFF
--- a/packet/config.go
+++ b/packet/config.go
@@ -2,6 +2,7 @@ package packet
 
 import (
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/packethost/packngo"
 )
 
@@ -15,5 +16,7 @@ type Config struct {
 
 // Client() returns a new client for accessing Packet's API.
 func (c *Config) Client() *packngo.Client {
-	return packngo.NewClient(consumerToken, c.AuthToken, cleanhttp.DefaultClient())
+	client := cleanhttp.DefaultClient()
+	client.Transport = logging.NewTransport("Packet", client.Transport)
+	return packngo.NewClient(consumerToken, c.AuthToken, client)
 }


### PR DESCRIPTION
It took me a while to understand what's happening behind the scenes while debugging something as simple as invalid token (401). Admittedly Packet API should be returning an error in the body of the response, but this can be useful in other cases.

It is in line with how we enable HTTP logging in other providers, e.g. github:
https://github.com/terraform-providers/terraform-provider-github/blob/master/github/config.go#L31

## Example

```
2017-09-12T07:43:28.600+0100 [DEBUG] plugin.terraform-provider-packet: 2017/09/12 07:43:28 [DEBUG] Packet API Request Details:
2017-09-12T07:43:28.600+0100 [DEBUG] plugin.terraform-provider-packet: ---[ REQUEST ]---------------------------------------
2017-09-12T07:43:28.600+0100 [DEBUG] plugin.terraform-provider-packet: GET /users HTTP/1.1
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: Host: api.packet.net
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: User-Agent: packngo/0.1.0
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: Connection: close
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: Accept: application/json
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: Content-Type: application/json
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: X-Auth-Token: v
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: X-Consumer-Token: aZ9GmqHTPtxevvFq9SK3Pi2yr9YCbRzduCSXF2SNem5sjB91mDq7Th3ZwTtRqMWZ
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: Accept-Encoding: gzip
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: 
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: 
2017-09-12T07:43:28.601+0100 [DEBUG] plugin.terraform-provider-packet: -----------------------------------------------------
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: 2017/09/12 07:43:31 [DEBUG] Packet API Response Details:
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: ---[ RESPONSE ]--------------------------------------
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: HTTP/1.1 401 Unauthorized
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Connection: close
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Transfer-Encoding: chunked
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Cache-Control: no-cache
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Content-Type: application/json
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Date: Tue, 12 Sep 2017 06:43:35 GMT
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Server: nginx
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Status: 401 Unauthorized
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: Vary: Origin
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: X-Request-Id: 375a92e1-2a88-4525-9b31-730a678a29cb
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: X-Runtime: 0.009597
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: 
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: 28
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: 0
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: 
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: 
2017-09-12T07:43:31.007+0100 [DEBUG] plugin.terraform-provider-packet: -----------------------------------------------------
```