### PR TITLE
Enable next-available hw resevation in device resource

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -157,7 +157,14 @@ func resourcePacketDevice() *schema.Resource {
 			"hardware_reservation_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "next-available" && len(old) > 0 {
+						return true
+					}
+					return false
+				},
 			},
 
 			"tags": &schema.Schema{

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
   doc.
 * `always_pxe` (Optional) - If true, a device with OS `custom_ipxe` will
   continue to boot via iPXE on reboots.
-* `hardware_reservation_id` (Optional) - The id of hardware reservation where you want this device deployed
+* `hardware_reservation_id` (Optional) - The id of hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This makes it possible to provision device on reserved hardware without explicitly specifying the UUID of the hw reservation. Packet has customer demand for this.

In Packet this is done by passing `next-available` instead of the hw reservation ID when creating a device. The created device then has the UUID of the used hw reservation in the resource attributes.  

I realize it's a bit terraform-unfriendly, and that's why I had to specify the DiffSuppressFunc. The device creation did not change, but the behavior on update is:
If new hwr\_id (value from tf file) is "next-available" and old hwr\_id (value from API read) is non-empty; then suppress diff (i.e. do skip, even though this "ForceNew" field would normally cause resource update).

It's alright this way I think - if "next-available" is in the hwr\_id field, and computed hwr\_id from the API is non-empty, we don't want to do anyhting.

This would work for import too I think.

@radeksimko, please check this out, even though I think this PR will not make you very happy.