### PR TITLE
make IP reserved block resource importable

### DIFF
--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -3,6 +3,7 @@ package packet
 import (
 	"errors"
 	"fmt"
+	"path"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/packethost/packngo"
@@ -75,6 +76,9 @@ func resourcePacketReservedIPBlock() *schema.Resource {
 		Create: resourcePacketReservedIPBlockCreate,
 		Read:   resourcePacketReservedIPBlockRead,
 		Delete: resourcePacketReservedIPBlockDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: reservedBlockSchema,
 	}
@@ -142,6 +146,7 @@ func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{})
 	d.Set("management", reservedBlock.Management)
 	d.Set("manageable", reservedBlock.Manageable)
 	d.Set("quantity", cidrToQuantity[reservedBlock.CIDR])
+	d.Set("project_id", path.Base(reservedBlock.Project.Href))
 	d.Set("cidr_notation", fmt.Sprintf("%s/%d", reservedBlock.Address, reservedBlock.CIDR))
 
 	return nil

--- a/packet/resource_packet_reserved_ip_block_test.go
+++ b/packet/resource_packet_reserved_ip_block_test.go
@@ -34,6 +34,22 @@ func TestAccPacketReservedIPBlock_Basic(t *testing.T) {
 						"packet_reserved_ip_block.test", "management", "false"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccPacketReservedIPBlock_importBasic(t *testing.T) {
+
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketReservedIPBlockDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPacketReservedIPBlockConfig_basic(rs),
+			},
 			resource.TestStep{
 				ResourceName:      "packet_reserved_ip_block.test",
 				ImportState:       true,

--- a/packet/resource_packet_reserved_ip_block_test.go
+++ b/packet/resource_packet_reserved_ip_block_test.go
@@ -34,6 +34,11 @@ func TestAccPacketReservedIPBlock_Basic(t *testing.T) {
 						"packet_reserved_ip_block.test", "management", "false"),
 				),
 			},
+			resource.TestStep{
+				ResourceName:      "packet_reserved_ip_block.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
This PR makes it possible to import IP reserved blocks for a project.

It wasn't possible before, because of missing link to parent project in the reserved block resource, but they have put it in place in the API so import is possible.