### PR TITLE
reflect API change in IP block reservation

### DIFF
--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -105,6 +105,7 @@ func resourcePacketReservedIPBlockCreate(d *schema.ResourceData, meta interface{
 	d.Set("facility", facility)
 	d.Set("quantity", quantity)
 	d.Set("project_id", projectID)
+	d.SetId(blockAddr.ID)
 
 	return resourcePacketReservedIPBlockRead(d, meta)
 }

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -112,10 +112,8 @@ func resourcePacketReservedIPBlockCreate(d *schema.ResourceData, meta interface{
 func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 	id := d.Id()
-	var reservedBlock *packngo.IPAddressReservation
-	var err error
 
-	reservedBlock, _, err = client.ProjectIPs.Get(id)
+	reservedBlock, _, err := client.ProjectIPs.Get(id)
 	if err != nil {
 		return fmt.Errorf("Error reading IP address block with ID %s: %s", id, err)
 	}

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -1,7 +1,6 @@
 package packet
 
 import (
-	"errors"
 	"fmt"
 	"path"
 
@@ -113,24 +112,12 @@ func resourcePacketReservedIPBlockCreate(d *schema.ResourceData, meta interface{
 func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 	id := d.Id()
-	cidrNotation := d.Get("cidr_notation").(string)
-	projectID := d.Get("project_id").(string)
 	var reservedBlock *packngo.IPAddressReservation
 	var err error
 
-	if len(id) == 0 {
-		if len(cidrNotation) == 0 {
-			return errors.New("can't read reserved IP block: both ID and cidr_notation fields are empty")
-		}
-		reservedBlock, _, err = client.ProjectIPs.GetByCIDR(projectID, cidrNotation)
-		if err != nil {
-			return fmt.Errorf("Error re-reading IP block with CIDR notation %s: %s", cidrNotation, err)
-		}
-	} else {
-		reservedBlock, _, err = client.ProjectIPs.Get(id)
-		if err != nil {
-			return fmt.Errorf("Error reading IP address block with ID %s: %s", id, err)
-		}
+	reservedBlock, _, err = client.ProjectIPs.Get(id)
+	if err != nil {
+		return fmt.Errorf("Error reading IP address block with ID %s: %s", id, err)
 	}
 	cidrToQuantity := map[int]int{32: 1, 31: 2, 30: 4, 29: 8, 28: 16, 27: 32, 26: 64, 25: 128, 24: 256}
 

--- a/vendor/github.com/packethost/packngo/devices.go
+++ b/vendor/github.com/packethost/packngo/devices.go
@@ -39,6 +39,7 @@ type Device struct {
 	Plan                *Plan                  `json:"plan,omitempty"`
 	Facility            *Facility              `json:"facility,omitempty"`
 	Project             *Project               `json:"project,omitempty"`
+	ProvisionEvents     []*ProvisionEvent      `json:"provisioning_events,omitempty"`
 	ProvisionPer        float32                `json:"provisioning_percentage,omitempty"`
 	UserData            string                 `json:"userdata,omitempty"`
 	RootPassword        string                 `json:"root_password,omitempty"`
@@ -48,6 +49,17 @@ type Device struct {
 	SpotInstance        bool                   `json:"spot_instance,omitempty"`
 	SpotPriceMax        float64                `json:"spot_price_max,omitempty"`
 	TerminationTime     *Timestamp             `json:"termination_time,omitempty"`
+}
+
+type ProvisionEvent struct {
+	ID            string     `json:"id"`
+	Body          string     `json:"body"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	Href          string     `json:"href"`
+	Interpolated  string     `json:"interpolated"`
+	Relationships []Href     `json:"relationships"`
+	State         string     `json:"state"`
+	Type          string     `json:"type"`
 }
 
 func (d Device) String() string {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -620,10 +620,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "feKnQI4npXRjgb4DZBjeE9mE3SQ=",
+			"checksumSHA1": "6MfBLocz5Iqqh/K/rygGX3LlVz0=",
 			"path": "github.com/packethost/packngo",
-			"revision": "07f4fe810b9a55c343792f214c673204e5f85afd",
-			"revisionTime": "2017-09-25T13:31:01Z",
+			"revision": "e70fa589581796f9faf190dc677a2d76a09bb16e",
+			"revisionTime": "2017-10-09T15:49:01Z",
 			"version": "master",
 			"versionExact": "master"
 		},


### PR DESCRIPTION
There was an API change described in https://github.com/packethost/packngo/pull/47 on 9.10.2017 3:30 UTC

This PR incorporates it to the terraform provider.

Before merging this, I check relevant acceptance tests.

This is a breaking change, so I merge without review. I will ask for re-release.




