### PR TITLE
Add datasource for pre-created (elastic) IP blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.1.1 (Unreleased)
+## 1.2.0 (Unreleased)
+
+BACKWARDS INCOMPATIBILITIES / NOTES:
+
+* [#37](https://github.com/terraform-providers/terraform-provider-packet/issues/37), changes computation of packet_reserved_ip_block.cidr_notation. In case you use that attribute down the chain, you will need to refresh and recreate the resource in which you use it.
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.1.1 (Unreleased)
+
+IMPROVEMENTS:
+
+* datasource/packet_precreated_ip_block: Add Datasource for precreated IP blocks, so that users can assign subnets from those ([#36](https://github.com/terraform-providers/terraform-provider-packet/issues/36))
+
 ## 1.1.0 (October 09, 2017)
 
 INTERNAL:

--- a/packet/datasource_packet_precreated_ip_block.go
+++ b/packet/datasource_packet_precreated_ip_block.go
@@ -1,0 +1,94 @@
+package packet
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourcePacketPreCreatedIPBlock() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePacketReservedIPBlockRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"address_family": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"public": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"facility": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"quantity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cidr_notation": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"netmask": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cidr": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"management": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"manageable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	projectID := d.Get("project_id").(string)
+	log.Println("[DEBUG] packet_precreated_ip_block - getting list of IPs in a project")
+	ips, _, err := client.ProjectIPs.List(projectID)
+	if err != nil {
+		return err
+	}
+	ipv := d.Get("address_family").(int)
+	public := d.Get("public").(bool)
+	facility := d.Get("facility").(string)
+
+	for _, ip := range ips {
+		if ip.Public == public && ip.AddressFamily == ipv && facility == ip.Facility.Code {
+			loadBlock(d, &ip)
+			break
+		}
+	}
+	if d.Get("cidr_notation") == "" {
+		return fmt.Errorf("Could not find matching reserved block, all IPs were %v", ips)
+	}
+	return nil
+
+}

--- a/packet/datasource_packet_precreated_ip_block_test.go
+++ b/packet/datasource_packet_precreated_ip_block_test.go
@@ -1,0 +1,66 @@
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPacketPreCreatedIPBlock_Basic(t *testing.T) {
+
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testPreCreatedIPBlockConfig_Basic(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.packet_precreated_ip_block.test", "cidr_notation"),
+					resource.TestCheckResourceAttrPair(
+						"packet_ip_attachment.test", "device_id",
+						"packet_device.test", "id"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "packet_ip_attachment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testPreCreatedIPBlockConfig_Basic(name string) string {
+	return fmt.Sprintf(`
+
+resource "packet_project" "test" {
+    name = "%s"
+}
+
+resource "packet_device" "test" {
+  hostname         = "tftest"
+  plan             = "baremetal_0"
+  facility         = "ewr1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
+}
+
+data "packet_precreated_ip_block" "test" {
+    facility         = "ewr1"
+    project_id       = "${packet_device.test.project_id}"
+    address_family   = 6
+    public           = true
+}
+
+resource "packet_ip_attachment" "test" {
+    device_id = "${packet_device.test.id}"
+    cidr_notation = "${cidrsubnet(data.packet_precreated_ip_block.test.cidr_notation,8,2)}"
+}
+`, name)
+}

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -16,6 +16,9 @@ func Provider() terraform.ResourceProvider {
 				Description: "The API auth key for API operations.",
 			},
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"packet_precreated_ip_block": dataSourcePacketPreCreatedIPBlock(),
+		},
 
 		ResourcesMap: map[string]*schema.Resource{
 			"packet_device":            resourcePacketDevice(),

--- a/packet/resource_packet_ip_attachment.go
+++ b/packet/resource_packet_ip_attachment.go
@@ -69,7 +69,7 @@ func resourcePacketIPAttachmentRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("device_id", path.Base(assignment.AssignedTo.Href))
 	d.Set("cidr_notation",
-		fmt.Sprintf("%s/%d", assignment.Address, assignment.CIDR))
+		fmt.Sprintf("%s/%d", assignment.Network, assignment.CIDR))
 
 	return nil
 }

--- a/website/docs/d/precreated_ip_block.html.markdown
+++ b/website/docs/d/precreated_ip_block.html.markdown
@@ -1,0 +1,66 @@
+---
+lauoyt: "packet"
+page_title: "Packet: precreated_ip_block"
+sidebar_current: "docs-packet-datasource-precreated-ip-block"
+description: |-
+  Load automatically created IP blocks from your Packet project
+---
+
+# packet\_precreated\_ip\_block
+
+Use this data source to get CIDR expression for precreated IPv6 and IPv4 blocks in Packet.
+You can then use the cidrsubnet TF builtin function to derive subnets.
+
+## Example Usage
+
+```hcl
+
+# Create project, device in it, and then assign /64 subnet from precreated block
+# to the new device
+
+resource "packet_project" "test" {
+    name = "testpro"
+}
+
+
+resource "packet_device" "web1" {
+  hostname         = "tftest"
+  plan             = "baremetal_0"
+  facility         = "ewr1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
+}
+
+# we have to make the datasource depend on the device. Here I do it implicitly
+# with the project_id param, because an explicity "depends_on" attribute in
+# a datasource taints the state:
+# https://github.com/hashicorp/terraform/issues/11806
+data "packet_precreated_ip_block" "test" {
+    facility         = "ewr1"
+    project_id       = "${packet_device.test.project_id}"
+    address_family   = 6
+    public           = true
+}
+
+# The precreated IPv6 blocks are /56, so to get /64, we specify 8 more bits for network.
+# The cirdsubnet interpolation will pick second /64 subnet from the precreated block.
+
+resource "packet_ip_attachment" "from_ipv6_block" {
+    device_id = "${packet_device.web1.id}"
+    cidr_notation = "${cidrsubnet(data.packet_precreated_ip_block.test.cidr_notation,8,2)}"
+}
+
+```
+
+## Argument Reference
+
+ * `project_id` - (Required) ID of the project where the searched block should be.
+ * `address_family` - (Required) 4 or 6, depending on which block you are looking for.
+ * `public` - (Required) Whether to look for public or private block. 
+ * `facility` - (Required) Facility of the searched block.
+
+## Attributes Reference
+
+ * `cidr_notation` - CIDR notation of the looked up block.
+

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -8,7 +8,17 @@
 
         <li<%= sidebar_current("docs-packet-index") %>>
           <a href="/docs/providers/packet/index.html">Packet Provider</a>
-        </li>
+       </li>
+
+       <li<%= sidebar_current("docs-packet-datasource") %>>
+         <a href="#">Data Sources</a>
+         <ul class="nav nav-visible">
+           <li<%= sidebar_current("docs-packet-datasource-precreated-ip-block") %>>
+             <a href="/docs/providers/packet/d/precreated_ip_block.html">precreated_ip_block</a>
+           </li>
+         </ul>
+       </li>
+
 
         <li<%= sidebar_current("docs-packet-resource") %>>
           <a href="#">Resources</a>


### PR DESCRIPTION
This PR adds a datasource for reserved IP blocks so that users can take advantage of the pre-created IPv6 and IPv4 blocks.
