### PR TITLE
Set ForceNew for user_data fixing #42

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -135,6 +135,7 @@ func resourcePacketDevice() *schema.Resource {
 			"user_data": &schema.Schema{
 				Type:      schema.TypeString,
 				Optional:  true,
+				ForceNew:  true,
 				Sensitive: true,
 			},
 


### PR DESCRIPTION
After reading the docs a bit I realize that if your provider doesn't support updating
a property the best solution is probably to label said property "ForceNew".

For user_data this is probably a rather desired property, since user_data is often used to
initialize the system. So force recreation of the resource might even be better than updating
user_data, which would still leave users wanting to have their machine reboot or reformatted
(in many instances).