### PR TITLE
Added Organization resource.

### DIFF
--- a/packet/provider.go
+++ b/packet/provider.go
@@ -24,6 +24,7 @@ func Provider() terraform.ResourceProvider {
 			"packet_device":            resourcePacketDevice(),
 			"packet_ssh_key":           resourcePacketSSHKey(),
 			"packet_project":           resourcePacketProject(),
+			"packet_organization":      resourcePacketOrganization(),
 			"packet_volume":            resourcePacketVolume(),
 			"packet_volume_attachment": resourcePacketVolumeAttachment(),
 			"packet_reserved_ip_block": resourcePacketReservedIPBlock(),

--- a/packet/resource_packet_organization.go
+++ b/packet/resource_packet_organization.go
@@ -1,0 +1,155 @@
+package packet
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func resourcePacketOrganization() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePacketOrganizationCreate,
+		Read:   resourcePacketOrganizationRead,
+		Update: resourcePacketOrganizationUpdate,
+		Delete: resourcePacketOrganizationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Required: false,
+			},
+
+			"website": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Required: false,
+			},
+
+			"twitter": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Required: false,
+			},
+
+			"logo": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Required: false,
+			},
+
+			"created": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"updated": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePacketOrganizationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	createRequest := &packngo.OrganizationCreateRequest{
+		Name: d.Get("name").(string),
+	}
+
+	if attr, ok := d.GetOk("website"); ok {
+		createRequest.Website = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("description"); ok {
+		createRequest.Description = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("twitter"); ok {
+		createRequest.Twitter = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("logo"); ok {
+		createRequest.Logo = attr.(string)
+	}
+
+	org, _, err := client.Organizations.Create(createRequest)
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	d.SetId(org.ID)
+
+	return resourcePacketOrganizationRead(d, meta)
+}
+
+func resourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	key, _, err := client.Organizations.Get(d.Id())
+	if err != nil {
+		err = friendlyError(err)
+
+		// If the project somehow already destroyed, mark as succesfully gone.
+		if isNotFound(err) {
+			d.SetId("")
+
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("id", key.ID)
+	d.Set("name", key.Name)
+	d.Set("description", key.Description)
+	d.Set("website", key.Website)
+	d.Set("twitter", key.Twitter)
+	d.Set("logo", key.Logo)
+	d.Set("created", key.Created)
+	d.Set("updated", key.Updated)
+
+	return nil
+}
+
+func resourcePacketOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+	website := d.Get("website").(string)
+	twitter := d.Get("twitter").(string)
+	logo := d.Get("logo").(string)
+
+	updateRequest := &packngo.OrganizationUpdateRequest{
+		Name:        &name,
+		Description: &description,
+		Website:     &website,
+		Twitter:     &twitter,
+		Logo:        &logo,
+	}
+
+	_, _, err := client.Organizations.Update(d.Get("id").(string), updateRequest)
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	return resourcePacketOrganizationRead(d, meta)
+}
+
+func resourcePacketOrganizationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	_, err := client.Organizations.Delete(d.Id())
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/packet/resource_packet_organization.go
+++ b/packet/resource_packet_organization.go
@@ -120,21 +120,33 @@ func resourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) er
 func resourcePacketOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
 
-	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	website := d.Get("website").(string)
-	twitter := d.Get("twitter").(string)
-	logo := d.Get("logo").(string)
+	updateRequest := &packngo.OrganizationUpdateRequest{}
 
-	updateRequest := &packngo.OrganizationUpdateRequest{
-		Name:        &name,
-		Description: &description,
-		Website:     &website,
-		Twitter:     &twitter,
-		Logo:        &logo,
+	if d.HasChange("name") {
+		oName := d.Get("name").(string)
+		updateRequest.Name = &oName
 	}
 
-	_, _, err := client.Organizations.Update(d.Get("id").(string), updateRequest)
+	if d.HasChange("description") {
+		oDescription := d.Get("description").(string)
+		updateRequest.Description = &oDescription
+	}
+
+	if d.HasChange("website") {
+		oWebsite := d.Get("website").(string)
+		updateRequest.Website = &oWebsite
+	}
+
+	if d.HasChange("twitter") {
+		oTwitter := d.Get("twitter").(string)
+		updateRequest.Twitter = &oTwitter
+	}
+
+	if d.HasChange("logo") {
+		oLogo := d.Get("logo").(string)
+		updateRequest.Logo = &oLogo
+	}
+	_, _, err := client.Organizations.Update(d.Id(), updateRequest)
 	if err != nil {
 		return friendlyError(err)
 	}

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -1,0 +1,89 @@
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/packethost/packngo"
+)
+
+func TestAccOrgCreate(t *testing.T) {
+	var org packngo.Organization
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketOrgDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPacketOrgConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketOrgExists("packet_organization.test", &org),
+					testAccCheckPacketOrgAttributes(&org),
+					resource.TestCheckResourceAttr(
+						"packet_organization.test", "name", "foobar"),
+					resource.TestCheckResourceAttr(
+						"packet_organization.test", "description", "quux"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPacketOrgDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*packngo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "packet_organization" {
+			continue
+		}
+		if _, _, err := client.Organizations.Get(rs.Primary.ID); err == nil {
+			return fmt.Errorf("Organization still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckPacketOrgAttributes(org *packngo.Organization) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if org.Name != "foobar" {
+			return fmt.Errorf("Bad name: %s", org.Name)
+		}
+		return nil
+	}
+}
+
+func testAccCheckPacketOrgExists(n string, org *packngo.Organization) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*packngo.Client)
+
+		foundOrg, _, err := client.Organizations.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if foundOrg.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found: %v - %v", rs.Primary.ID, foundOrg)
+		}
+
+		*org = *foundOrg
+
+		return nil
+	}
+}
+
+var testAccCheckPacketOrgConfigBasic = fmt.Sprintf(`
+resource "packet_organization" "test" {
+		name = "foobar"
+		description = "quux"
+}`)

--- a/website/docs/r/organization.html.markdown
+++ b/website/docs/r/organization.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "packet"
+page_title: "Packet: packet_organization"
+sidebar_current: "docs-packet-resource-organization"
+description: |-
+  Provides a Packet Organization resource.
+---
+
+# packet\_organization
+
+Provides a resource to manage organization resource in Packet.
+
+## Example Usage
+
+```hcl
+# Create a new Project
+resource "packet_organization" "tf_organization_1" {
+  name = "foobar"
+  description = "quux"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Organization.
+* `description` - Description string.
+* `website` - Website link.
+* `twitter` - Twitter handle.
+* `logo` - Logo URL.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique ID of the organization.
+* `name` - The name of the Organization.
+* `description` - Description string.
+* `website` - Website link.
+* `twitter` - Twitter handle.
+* `logo` - Logo URL.

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -26,6 +26,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Project on Packet.net
 * `payment_method_id` - The UUID of payment method for this project. If you keep it empty, Packet API will pick your default Payment Method.
+* `organization_id` - The UUID of Organization under which you want to create the project. If you leave it out, the project will be create under your the default Organization of your account.
 
 ## Attributes Reference
 
@@ -33,5 +34,6 @@ The following attributes are exported:
 
 * `id` - The unique ID of the project
 * `payment_method_id` - The UUID of payment method for this project.
+* `organization_id` - The UUID of this project's parent organization.
 * `created` - The timestamp for when the Project was created
 * `updated` - The timestamp for the last time the Project was updated

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -29,6 +29,9 @@
             <li<%= sidebar_current("docs-packet-resource-project") %>>
               <a href="/docs/providers/packet/r/project.html">packet_project</a>
             </li>
+            <li<%= sidebar_current("docs-packet-resource-organization") %>>
+              <a href="/docs/providers/packet/r/organization.html">packet_organization</a>
+            </li>
             <li<%= sidebar_current("docs-packet-resource-ssh-key") %>>
               <a href="/docs/providers/packet/r/ssh_key.html">packet_ssh_key</a>
             </li>


### PR DESCRIPTION
Allow create projects with organization id.

```
resource "packet_organization" "test" {
  name = "foobar"
  description = "test"
  website = "http://google.com"
  twitter = "miry_sof"
}

resource "packet_project" "foobar" {
  name = "foobar"
  organization_id = "${packet_organization.test.id}"
}
```

It is example how it could be done.

Another solution to move `packet_organization` under `provider` resource similar to https://www.terraform.io/docs/providers/aws/, with out create and update resources.