### PR TITLE
[datasource] packet_operating_system -> data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.2.5 (Unreleased)
+
+FEATURES:
+
+* **New Data Source:** `packet_operating_system` ([#70](https://github.com/terraform-providers/terraform-provider-profitbricks/pull/70))
+  
+
 ## 1.2.4 (May 31, 2018)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 
-* **New Data Source:** `packet_operating_system` ([#70](https://github.com/terraform-providers/terraform-provider-profitbricks/pull/70))
+* **New Data Source:** `packet_operating_system` ([#70](https://github.com/terraform-providers/terraform-provider-packet/pull/70))
   
 
 ## 1.2.4 (May 31, 2018)

--- a/packet/config.go
+++ b/packet/config.go
@@ -14,9 +14,9 @@ type Config struct {
 	AuthToken string
 }
 
-// Client() returns a new client for accessing Packet's API.
+// Client returns a new client for accessing Packet's API.
 func (c *Config) Client() *packngo.Client {
 	client := cleanhttp.DefaultClient()
 	client.Transport = logging.NewTransport("Packet", client.Transport)
-	return packngo.NewClient(consumerToken, c.AuthToken, client)
+	return packngo.NewClientWithAuth(consumerToken, c.AuthToken, client)
 }

--- a/packet/datasource_packet_operating_system.go
+++ b/packet/datasource_packet_operating_system.go
@@ -1,0 +1,125 @@
+package packet
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourceOperatingSystem() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePacketOperatingSystemRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"distro": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"provisionable_on": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourcePacketOperatingSystemRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	name, nameOK := d.GetOk("name")
+	distro, distroOK := d.GetOk("distro")
+	version, versionOK := d.GetOk("version")
+	provisionableOn, provisionableOnOK := d.GetOk("provisionable_on")
+
+	if !nameOK && !distroOK && !versionOK && !provisionableOnOK {
+		return fmt.Errorf("One of name, distro, version, or provisionable_on must be assigned")
+	}
+
+	log.Println("[DEBUG] ******")
+	log.Println("[DEBUG] params", name, distro, version, provisionableOn)
+	log.Println("[DEBUG] ******")
+
+	oss, _, err := client.OperatingSystems.List()
+	if err != nil {
+		return err
+	}
+
+	final := []packngo.OS{}
+	temp := []packngo.OS{}
+
+	if nameOK {
+		for _, os := range oss {
+			if strings.Contains(strings.ToLower(os.Name), strings.ToLower(name.(string))) {
+				temp = append(temp, os)
+			}
+			final = temp
+		}
+	}
+
+	if distroOK {
+		temp = []packngo.OS{}
+		if len(temp) == 0 {
+			final = oss
+		}
+		for _, v := range final {
+			if v.Distro == distro.(string) {
+				temp = append(temp, v)
+			}
+		}
+		final = temp
+	}
+
+	if versionOK {
+		temp = []packngo.OS{}
+		if len(final) == 0 {
+			final = oss
+		}
+		for _, v := range final {
+			if v.Version == version.(string) {
+				temp = append(temp, v)
+			}
+		}
+		final = temp
+	}
+
+	if provisionableOnOK {
+		temp = []packngo.OS{}
+		if len(final) == 0 {
+			final = oss
+		}
+		for _, v := range final {
+			for _, po := range v.ProvisionableOn {
+				if po == provisionableOn.(string) {
+					temp = append(temp, v)
+				}
+			}
+		}
+		final = temp
+	}
+	log.Println("[DEBUG] RESULTS:", final)
+
+	if len(final) == 0 {
+		return fmt.Errorf("There are no operating systems that match the search criteria")
+	}
+
+	if len(final) > 1 {
+		return fmt.Errorf("There is more than one operating system that matches the search criteria")
+	}
+	for _, v := range final {
+		d.Set("name", v.Name)
+		d.Set("distro", v.Distro)
+		d.Set("version", v.Version)
+		d.SetId(v.Slug)
+	}
+	return nil
+}

--- a/packet/datasource_packet_operating_system.go
+++ b/packet/datasource_packet_operating_system.go
@@ -29,6 +29,10 @@ func dataSourceOperatingSystem() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"slug": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -119,6 +123,7 @@ func dataSourcePacketOperatingSystemRead(d *schema.ResourceData, meta interface{
 		d.Set("name", v.Name)
 		d.Set("distro", v.Distro)
 		d.Set("version", v.Version)
+		d.Set("slug", v.Slug)
 		d.SetId(v.Slug)
 	}
 	return nil

--- a/packet/datasource_packet_operating_system_test.go
+++ b/packet/datasource_packet_operating_system_test.go
@@ -1,0 +1,29 @@
+package packet
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPacketOperatingSystem_Basic(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{Config: testOperatingSystemConfig_Basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.packet_operating_system.example", "id", "coreos_alpha"),
+				),
+			},
+		},
+	})
+}
+
+const testOperatingSystemConfig_Basic = `
+	data "packet_operating_system" "example" {
+		name    = "Container"
+		distro  = "coreos"
+		version = "alpha"
+	  }`

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -18,6 +18,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"packet_precreated_ip_block": dataSourcePacketPreCreatedIPBlock(),
+			"packet_operating_system":    dataSourceOperatingSystem(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/vendor/github.com/packethost/packngo/README.md
+++ b/vendor/github.com/packethost/packngo/README.md
@@ -1,20 +1,51 @@
 # packngo
 Packet Go Api Client
 
-![](https://www.packet.net/media/labs/images/1679091c5a880faf6fb5e6087eb1b2dc/ULY7-hero.png)
+![](https://www.packet.net/media/images/xeiw-packettwitterprofilew.png)
 
-Committing
-----------
 
-Before committing, it's a good idea to run `gofmt -w *.go`. ([gofmt](https://golang.org/cmd/gofmt/))
+Installation
+------------
 
+`go get github.com/packethost/packngo`
 
 Usage
 -----
 
+To authenticate to the Packet API, you must have your API token exported in env var `PACKET_API_TOKEN`.
+
+This code snippet initializes Packet API client, and lists your Projects:
+
+```go
+package main
+
+import (
+	"log"
+
+	"github.com/packethost/packngo"
+)
+
+func main() {
+	c, err := packngo.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ps, _, err := c.Projects.List(nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, p := range ps {
+		log.Println(p.ID, p.Name)
+	}
+}
+
+```
+
 This lib is used by the official [terraform-provider-packet](https://github.com/terraform-providers/terraform-provider-packet).
 
-If you want to use it in your Go code, you can learn a lot from the `*_test.go` sources. Almost all out tests touch the Packet API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
+You can also learn a lot from the `*_test.go` sources. Almost all out tests touch the Packet API, so you can see how auth, querying and POSTing works. For example [devices_test.go](devices_test.go).
+
 
 
 Acceptance Tests
@@ -22,14 +53,20 @@ Acceptance Tests
 
 If you want to run tests against the actual Packet API, you must set envvar `PACKET_TEST_ACTUAL_API` to non-empty string for the `go test`. The device tests wait for the device creation, so it's best to run a few in parallel.
 
-To run all the tests, you can do
-
-```
-$ PACKNGO_TEST_ACTUAL_API=1 go test -v -parallel 8
-```
-
-It's also useful to run only single acceptance test at a time:
+To run a particular test, you can do
 
 ```
 $ PACKNGO_TEST_ACTUAL_API=1 go test -v -run=TestAccDeviceBasic
 ```
+
+If you want to see HTTP requests, set the `PACKNGO_DEBUG` env var to non-empty string, for example:
+
+```
+$ PACKNGO_DEBUG=1 PACKNGO_TEST_ACTUAL_API=1 go test -v -run=TestAccVolumeUpdate
+```
+
+
+Committing
+----------
+
+Before committing, it's a good idea to run `gofmt -w *.go`. ([gofmt](https://golang.org/cmd/gofmt/))

--- a/vendor/github.com/packethost/packngo/devices.go
+++ b/vendor/github.com/packethost/packngo/devices.go
@@ -20,6 +20,7 @@ type DeviceService interface {
 	PowerOn(string) (*Response, error)
 	Lock(string) (*Response, error)
 	Unlock(string) (*Response, error)
+	ListEvents(string, *ListOptions) ([]Event, *Response, error)
 }
 
 type devicesRoot struct {
@@ -45,7 +46,7 @@ type Device struct {
 	Plan                *Plan                  `json:"plan,omitempty"`
 	Facility            *Facility              `json:"facility,omitempty"`
 	Project             *Project               `json:"project,omitempty"`
-	ProvisionEvents     []*ProvisionEvent      `json:"provisioning_events,omitempty"`
+	ProvisionEvents     []*Event               `json:"provisioning_events,omitempty"`
 	ProvisionPer        float32                `json:"provisioning_percentage,omitempty"`
 	UserData            string                 `json:"userdata,omitempty"`
 	RootPassword        string                 `json:"root_password,omitempty"`
@@ -56,17 +57,7 @@ type Device struct {
 	SpotPriceMax        float64                `json:"spot_price_max,omitempty"`
 	TerminationTime     *Timestamp             `json:"termination_time,omitempty"`
 	NetworkPorts        []Port                 `json:"network_ports,omitempty"`
-}
-
-type ProvisionEvent struct {
-	ID            string     `json:"id"`
-	Body          string     `json:"body"`
-	CreatedAt     *Timestamp `json:"created_at,omitempty"`
-	Href          string     `json:"href"`
-	Interpolated  string     `json:"interpolated"`
-	Relationships []Href     `json:"relationships"`
-	State         string     `json:"state"`
-	Type          string     `json:"type"`
+	CustomData          map[string]interface{} `json:"customdata,omitempty"`
 }
 
 func (d Device) String() string {
@@ -91,6 +82,7 @@ type DeviceCreateRequest struct {
 	SpotInstance          bool       `json:"spot_instance,omitempty"`
 	SpotPriceMax          float64    `json:"spot_price_max,omitempty,string"`
 	TerminationTime       *Timestamp `json:"termination_time,omitempty"`
+	CustomData            string     `json:"customdata,omitempty"`
 }
 
 // DeviceUpdateRequest type used to update a Packet device
@@ -102,6 +94,7 @@ type DeviceUpdateRequest struct {
 	Tags          *[]string `json:"tags,omitempty"`
 	AlwaysPXE     *bool     `json:"always_pxe,omitempty"`
 	IPXEScriptURL *string   `json:"ipxe_script_url,omitempty"`
+	CustomData    *string   `json:"customdata,omitempty"`
 }
 
 func (d DeviceCreateRequest) String() string {
@@ -251,4 +244,11 @@ func (s *DeviceServiceOp) Unlock(deviceID string) (*Response, error) {
 	action := lockType{Locked: false}
 
 	return s.client.DoRequest("PATCH", path, action, nil)
+}
+
+// ListEvents returns list of device events
+func (s *DeviceServiceOp) ListEvents(deviceID string, listOpt *ListOptions) ([]Event, *Response, error) {
+	path := fmt.Sprintf("%s/%s%s", deviceBasePath, deviceID, eventBasePath)
+
+	return list(s.client, path, listOpt)
 }

--- a/vendor/github.com/packethost/packngo/email.go
+++ b/vendor/github.com/packethost/packngo/email.go
@@ -1,10 +1,21 @@
 package packngo
 
+import "fmt"
+
 const emailBasePath = "/emails"
+
+// EmailRequest type used to add an email address to the current user
+type EmailRequest struct {
+	Address string `json:"address,omitempty"`
+	Default *bool  `json:"default,omitempty"`
+}
 
 // EmailService interface defines available email methods
 type EmailService interface {
 	Get(string) (*Email, *Response, error)
+	Create(*EmailRequest) (*Email, *Response, error)
+	Update(string, *EmailRequest) (*Email, *Response, error)
+	Delete(string) (*Response, error)
 }
 
 // Email represents a user's email address
@@ -26,9 +37,47 @@ type EmailServiceOp struct {
 
 // Get retrieves an email by id
 func (s *EmailServiceOp) Get(emailID string) (*Email, *Response, error) {
+	path := fmt.Sprintf("%s/%s", emailBasePath, emailID)
 	email := new(Email)
 
-	resp, err := s.client.DoRequest("GET", emailBasePath, nil, email)
+	resp, err := s.client.DoRequest("GET", path, nil, email)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return email, resp, err
+}
+
+// Create adds a new email address to the current user.
+func (s *EmailServiceOp) Create(request *EmailRequest) (*Email, *Response, error) {
+	email := new(Email)
+
+	resp, err := s.client.DoRequest("POST", emailBasePath, request, email)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return email, resp, err
+}
+
+// Delete removes the email addres from the current user account
+func (s *EmailServiceOp) Delete(emailID string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", emailBasePath, emailID)
+
+	resp, err := s.client.DoRequest("DELETE", path, nil, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
+// Update email parameters
+func (s *EmailServiceOp) Update(emailID string, request *EmailRequest) (*Email, *Response, error) {
+	email := new(Email)
+	path := fmt.Sprintf("%s/%s", emailBasePath, emailID)
+
+	resp, err := s.client.DoRequest("PUT", path, request, email)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/vendor/github.com/packethost/packngo/events.go
+++ b/vendor/github.com/packethost/packngo/events.go
@@ -1,0 +1,81 @@
+package packngo
+
+import "fmt"
+
+const eventBasePath = "/events"
+
+// Event struct
+type Event struct {
+	ID            string     `json:"id,omitempty"`
+	State         string     `json:"state,omitempty"`
+	Type          string     `json:"type,omitempty"`
+	Body          string     `json:"body,omitempty"`
+	Relationships []Href     `json:"relationships,omitempty"`
+	Interpolated  string     `json:"interpolated,omitempty"`
+	CreatedAt     *Timestamp `json:"created_at,omitempty"`
+	Href          string     `json:"href,omitempty"`
+}
+
+type eventsRoot struct {
+	Events []Event `json:"events,omitempty"`
+	Meta   meta    `json:"meta,omitempty"`
+}
+
+// EventService interface defines available event functions
+type EventService interface {
+	List(*ListOptions) ([]Event, *Response, error)
+	Get(string, *ListOptions) (*Event, *Response, error)
+}
+
+// EventServiceOp implements EventService
+type EventServiceOp struct {
+	client *Client
+}
+
+// List returns all events
+func (s *EventServiceOp) List(listOpt *ListOptions) ([]Event, *Response, error) {
+	return list(s.client, eventBasePath, listOpt)
+}
+
+// Get returns an event by ID
+func (s *EventServiceOp) Get(eventID string, listOpt *ListOptions) (*Event, *Response, error) {
+	path := fmt.Sprintf("%s/%s", eventBasePath, eventID)
+	return get(s.client, path, listOpt)
+}
+
+// list helper function for all event functions
+func list(client *Client, path string, listOpt *ListOptions) ([]Event, *Response, error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	root := new(eventsRoot)
+
+	path = fmt.Sprintf("%s?%s", path, params)
+
+	resp, err := client.DoRequest("GET", path, nil, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Events, resp, err
+}
+
+func get(client *Client, path string, listOpt *ListOptions) (*Event, *Response, error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	event := new(Event)
+
+	path = fmt.Sprintf("%s?%s", path, params)
+
+	resp, err := client.DoRequest("GET", path, nil, event)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return event, resp, err
+}

--- a/vendor/github.com/packethost/packngo/hardware_reservations.go
+++ b/vendor/github.com/packethost/packngo/hardware_reservations.go
@@ -1,0 +1,100 @@
+package packngo
+
+import "fmt"
+
+const hardwareReservationBasePath = "/hardware-reservations"
+
+// HardwareReservationService interface defines available hardware reservation functions
+type HardwareReservationService interface {
+	Get(hardwareReservationID string, listOpt *ListOptions) (*HardwareReservation, *Response, error)
+	List(projectID string, listOpt *ListOptions) ([]HardwareReservation, *Response, error)
+	Move(string, string) (*HardwareReservation, *Response, error)
+}
+
+// HardwareReservationServiceOp implements HardwareReservationService
+type HardwareReservationServiceOp struct {
+	client *Client
+}
+
+// HardwareReservation struct
+type HardwareReservation struct {
+	ID        string    `json:"id,omitempty"`
+	ShortID   string    `json:"short_id,omitempty"`
+	Facility  Facility  `json:"facility,omitempty"`
+	Plan      Plan      `json:"plan,omitempty"`
+	Href      string    `json:"href,omitempty"`
+	Project   Project   `json:"project,omitempty"`
+	Device    *Device   `json:"device,omitempty"`
+	CreatedAt Timestamp `json:"created_at,omitempty"`
+}
+
+type hardwareReservationRoot struct {
+	HardwareReservations []HardwareReservation `json:"hardware_reservations"`
+	Meta                 meta                  `json:"meta"`
+}
+
+// List returns all hardware reservations for a given project
+func (s *HardwareReservationServiceOp) List(projectID string, listOpt *ListOptions) (reservations []HardwareReservation, resp *Response, err error) {
+	root := new(hardwareReservationRoot)
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	path := fmt.Sprintf("%s/%s%s?%s", projectBasePath, projectID, hardwareReservationBasePath, params)
+
+	for {
+		subset := new(hardwareReservationRoot)
+
+		resp, err = s.client.DoRequest("GET", path, nil, root)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		reservations = append(reservations, root.HardwareReservations...)
+
+		if subset.Meta.Next != nil && (listOpt == nil || listOpt.Page == 0) {
+			path = subset.Meta.Next.Href
+			if params != "" {
+				path = fmt.Sprintf("%s&%s", path, params)
+			}
+			continue
+		}
+
+		return
+	}
+}
+
+// Get returns a single hardware reservation
+func (s *HardwareReservationServiceOp) Get(hardwareReservationdID string, listOpt *ListOptions) (*HardwareReservation, *Response, error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	hardwareReservation := new(HardwareReservation)
+
+	path := fmt.Sprintf("%s/%s?%s", hardwareReservationBasePath, hardwareReservationdID, params)
+
+	resp, err := s.client.DoRequest("GET", path, nil, hardwareReservation)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hardwareReservation, resp, err
+}
+
+// Move a hardware reservation to another project
+func (s *HardwareReservationServiceOp) Move(hardwareReservationdID, projectID string) (*HardwareReservation, *Response, error) {
+	hardwareReservation := new(HardwareReservation)
+	path := fmt.Sprintf("%s/%s/%s", hardwareReservationBasePath, hardwareReservationdID, "move")
+	body := map[string]string{}
+	body["project_id"] = projectID
+
+	resp, err := s.client.DoRequest("POST", path, body, hardwareReservation)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return hardwareReservation, resp, err
+}

--- a/vendor/github.com/packethost/packngo/ip.go
+++ b/vendor/github.com/packethost/packngo/ip.go
@@ -182,7 +182,7 @@ func (i *ProjectIPServiceOp) Remove(ipReservationID string) (*Response, error) {
 
 // AvailableAddresses lists addresses available from a reserved block
 func (i *ProjectIPServiceOp) AvailableAddresses(ipReservationID string, r *AvailableRequest) ([]string, *Response, error) {
-	path := fmt.Sprintf("%s/%s/available", ipBasePath, ipReservationID)
+	path := fmt.Sprintf("%s/%s/available?cidr=%d", ipBasePath, ipReservationID, r.CIDR)
 	ar := new(AvailableResponse)
 
 	resp, err := i.client.DoRequest("GET", path, r, ar)

--- a/vendor/github.com/packethost/packngo/notifications.go
+++ b/vendor/github.com/packethost/packngo/notifications.go
@@ -1,0 +1,96 @@
+package packngo
+
+import "fmt"
+
+const notificationBasePath = "/notifications"
+
+// Notification struct
+type Notification struct {
+	ID        string    `json:"id,omitempty"`
+	Type      string    `json:"type,omitempty"`
+	Body      string    `json:"body,omitempty"`
+	Severity  string    `json:"severity,omitempty"`
+	Read      bool      `json:"read,omitempty"`
+	Context   string    `json:"context,omitempty"`
+	CreatedAt Timestamp `json:"created_at,omitempty"`
+	UpdatedAt Timestamp `json:"updated_at,omitempty"`
+	User      Href      `json:"user,omitempty"`
+	Href      string    `json:"href,omitempty"`
+}
+
+type notificationsRoot struct {
+	Notifications []Notification `json:"notifications,omitempty"`
+	Meta          meta           `json:"meta,omitempty"`
+}
+
+// NotificationService interface defines available event functions
+type NotificationService interface {
+	List(*ListOptions) ([]Notification, *Response, error)
+	Get(string) (*Notification, *Response, error)
+	MarkAsRead(string) (*Notification, *Response, error)
+}
+
+// NotificationServiceOp implements NotificationService
+type NotificationServiceOp struct {
+	client *Client
+}
+
+// List returns all notifications
+func (s *NotificationServiceOp) List(listOpt *ListOptions) ([]Notification, *Response, error) {
+	return listNotifications(s.client, notificationBasePath, listOpt)
+}
+
+// Get returns a notification by ID
+func (s *NotificationServiceOp) Get(notificationID string) (*Notification, *Response, error) {
+	path := fmt.Sprintf("%s/%s", notificationBasePath, notificationID)
+	return getNotifications(s.client, path)
+}
+
+// Marks notification as read by ID
+func (s *NotificationServiceOp) MarkAsRead(notificationID string) (*Notification, *Response, error) {
+	path := fmt.Sprintf("%s/%s", notificationBasePath, notificationID)
+	return markAsRead(s.client, path)
+}
+
+// list helper function for all notification functions
+func listNotifications(client *Client, path string, listOpt *ListOptions) ([]Notification, *Response, error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+
+	root := new(notificationsRoot)
+
+	path = fmt.Sprintf("%s?%s", path, params)
+
+	resp, err := client.DoRequest("GET", path, nil, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Notifications, resp, err
+}
+
+func getNotifications(client *Client, path string) (*Notification, *Response, error) {
+
+	notification := new(Notification)
+
+	resp, err := client.DoRequest("GET", path, nil, notification)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return notification, resp, err
+}
+
+func markAsRead(client *Client, path string) (*Notification, *Response, error) {
+
+	notification := new(Notification)
+
+	resp, err := client.DoRequest("PUT", path, nil, notification)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return notification, resp, err
+}

--- a/vendor/github.com/packethost/packngo/operatingsystems.go
+++ b/vendor/github.com/packethost/packngo/operatingsystems.go
@@ -13,10 +13,11 @@ type osRoot struct {
 
 // OS represents a Packet operating system
 type OS struct {
-	Name    string `json:"name"`
-	Slug    string `json:"slug"`
-	Distro  string `json:"distro"`
-	Version string `json:"version"`
+	Name            string   `json:"name"`
+	Slug            string   `json:"slug"`
+	Distro          string   `json:"distro"`
+	Version         string   `json:"version"`
+	ProvisionableOn []string `json:"provisionable_on"`
 }
 
 func (o OS) String() string {

--- a/vendor/github.com/packethost/packngo/organizations.go
+++ b/vendor/github.com/packethost/packngo/organizations.go
@@ -13,6 +13,7 @@ type OrganizationService interface {
 	Update(string, *OrganizationUpdateRequest) (*Organization, *Response, error)
 	Delete(string) (*Response, error)
 	ListPaymentMethods(string) ([]PaymentMethod, *Response, error)
+	ListEvents(string, *ListOptions) ([]Event, *Response, error)
 }
 
 type organizationsRoot struct {
@@ -144,4 +145,11 @@ func (s *OrganizationServiceOp) ListPaymentMethods(organizationID string) ([]Pay
 	}
 
 	return root.PaymentMethods, resp, err
+}
+
+// ListEvents returns list of organization events
+func (s *OrganizationServiceOp) ListEvents(organizationID string, listOpt *ListOptions) ([]Event, *Response, error) {
+	path := fmt.Sprintf("%s/%s%s", organizationBasePath, organizationID, eventBasePath)
+
+	return list(s.client, path, listOpt)
 }

--- a/vendor/github.com/packethost/packngo/projects.go
+++ b/vendor/github.com/packethost/packngo/projects.go
@@ -1,20 +1,26 @@
 package packngo
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const projectBasePath = "/projects"
 
 // ProjectService interface defines available project methods
 type ProjectService interface {
-	List() ([]Project, *Response, error)
+	List(listOpt *ListOptions) ([]Project, *Response, error)
 	Get(string) (*Project, *Response, error)
+	GetExtra(projectID string, includes, excludes []string) (*Project, *Response, error)
 	Create(*ProjectCreateRequest) (*Project, *Response, error)
 	Update(string, *ProjectUpdateRequest) (*Project, *Response, error)
 	Delete(string) (*Response, error)
+	ListEvents(string, *ListOptions) ([]Event, *Response, error)
 }
 
 type projectsRoot struct {
 	Projects []Project `json:"projects"`
+	Meta     meta      `json:"meta"`
 }
 
 // Project represents a Packet project
@@ -62,15 +68,51 @@ type ProjectServiceOp struct {
 }
 
 // List returns the user's projects
-func (s *ProjectServiceOp) List() ([]Project, *Response, error) {
+func (s *ProjectServiceOp) List(listOpt *ListOptions) (projects []Project, resp *Response, err error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
 	root := new(projectsRoot)
 
-	resp, err := s.client.DoRequest("GET", projectBasePath, nil, root)
+	path := fmt.Sprintf("%s?%s", projectBasePath, params)
+
+	for {
+		resp, err = s.client.DoRequest("GET", path, nil, root)
+		if err != nil {
+			return nil, resp, err
+		}
+
+		projects = append(projects, root.Projects...)
+
+		if root.Meta.Next != nil && (listOpt == nil || listOpt.Page == 0) {
+			path = root.Meta.Next.Href
+			if params != "" {
+				path = fmt.Sprintf("%s&%s", path, params)
+			}
+			continue
+		}
+
+		return
+	}
+}
+
+// GetExtra returns a project by id with extra information
+func (s *ProjectServiceOp) GetExtra(projectID string, includes, excludes []string) (*Project, *Response, error) {
+	path := fmt.Sprintf("%s/%s", projectBasePath, projectID)
+	if includes != nil {
+		path += fmt.Sprintf("?include=%s", strings.Join(includes, ","))
+	} else if excludes != nil {
+		path += fmt.Sprintf("?exclude=%s", strings.Join(excludes, ","))
+	}
+
+	project := new(Project)
+	resp, err := s.client.DoRequest("GET", path, nil, project)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return root.Projects, resp, err
+	return project, resp, err
 }
 
 // Get returns a project by id
@@ -116,4 +158,11 @@ func (s *ProjectServiceOp) Delete(projectID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", projectBasePath, projectID)
 
 	return s.client.DoRequest("DELETE", path, nil, nil)
+}
+
+// ListEvents returns list of project events
+func (s *ProjectServiceOp) ListEvents(projectID string, listOpt *ListOptions) ([]Event, *Response, error) {
+	path := fmt.Sprintf("%s/%s%s", projectBasePath, projectID, eventBasePath)
+
+	return list(s.client, path, listOpt)
 }

--- a/vendor/github.com/packethost/packngo/spotmarketrequest.go
+++ b/vendor/github.com/packethost/packngo/spotmarketrequest.go
@@ -1,0 +1,112 @@
+package packngo
+
+import (
+	"fmt"
+	"math"
+)
+
+const spotMarketRequestBasePath = "/spot-market-requests"
+
+type SpotMarketRequestService interface {
+	List(string) ([]SpotMarketRequest, *Response, error)
+	Create(*SpotMarketRequestCreateRequest, string) (*SpotMarketRequest, *Response, error)
+	Delete(string, bool) (*Response, error)
+	Get(string, *ListOptions) (*SpotMarketRequest, *Response, error)
+}
+
+type SpotMarketRequestCreateRequest struct {
+	DevicesMax  int        `json:"devices_max"`
+	DevicesMin  int        `json:"devices_min"`
+	EndAt       *Timestamp `json:"end_at,omitempty"`
+	FacilityIDs []string   `json:"facility_ids"`
+	MaxBidPrice float64    `json:"max_bid_price"`
+
+	Parameters SpotMarketRequestInstanceParameters `json:"instance_parameters"`
+}
+
+type SpotMarketRequest struct {
+	SpotMarketRequestCreateRequest
+	ID         string     `json:"id"`
+	Devices    []Device   `json:"devices"`
+	Facilities []Facility `json:"facilities"`
+	Project    Project    `json:"project"`
+	Href       string     `json:"href"`
+}
+
+type SpotMarketRequestInstanceParameters struct {
+	AlwaysPXE       bool       `json:"always_pxe,omitempty"`
+	BillingCycle    string     `json:"billing_cycle"`
+	CustomData      string     `json:"customdata,omitempty"`
+	Description     string     `json:"description,omitempty"`
+	Features        []string   `json:"features,omitempty"`
+	Hostname        string     `json:"hostname,omitempty"`
+	Hostnames       []string   `json:"hostnames,omitempty"`
+	Locked          bool       `json:"locked,omitempty"`
+	OperatingSystem string     `json:"operating_system"`
+	Plan            string     `json:"plan"`
+	ProjectSSHKeys  []string   `json:"project_ssh_keys,omitempty"`
+	Tags            []string   `json:"tags"`
+	TerminationTime *Timestamp `json:"termination_time,omitempty"`
+	UserSSHKeys     []string   `json:"user_ssh_keys,omitempty"`
+	UserData        string     `json:"userdata"`
+}
+
+type SpotMarketRequestServiceOp struct {
+	client *Client
+}
+
+func roundPlus(f float64, places int) float64 {
+	shift := math.Pow(10, float64(places))
+	return math.Floor(f*shift+.5) / shift
+}
+
+func (s *SpotMarketRequestServiceOp) Create(cr *SpotMarketRequestCreateRequest, pID string) (*SpotMarketRequest, *Response, error) {
+	path := fmt.Sprintf("%s/%s%s?include=devices,project", projectBasePath, pID, spotMarketRequestBasePath)
+	cr.MaxBidPrice = roundPlus(cr.MaxBidPrice, 2)
+	smr := new(SpotMarketRequest)
+
+	resp, err := s.client.DoRequest("POST", path, cr, smr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return smr, resp, err
+}
+
+func (s *SpotMarketRequestServiceOp) List(pID string) ([]SpotMarketRequest, *Response, error) {
+	smrRoot := struct {
+		SMRs []SpotMarketRequest `json:"spot_market_requests"`
+	}{}
+
+	path := fmt.Sprintf("%s/%s%s?include=devices,project", projectBasePath, pID, spotMarketRequestBasePath)
+	resp, err := s.client.DoRequest("GET", path, nil, &smrRoot)
+	if err != nil {
+		return nil, resp, err
+	}
+	return smrRoot.SMRs, resp, nil
+}
+
+func (s *SpotMarketRequestServiceOp) Get(id string, listOpt *ListOptions) (*SpotMarketRequest, *Response, error) {
+	var params string
+	if listOpt != nil {
+		params = listOpt.createURL()
+	}
+	path := fmt.Sprintf("%s/%s?%s", spotMarketRequestBasePath, id, params)
+	smr := new(SpotMarketRequest)
+
+	resp, err := s.client.DoRequest("GET", path, nil, &smr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return smr, resp, err
+}
+
+func (s *SpotMarketRequestServiceOp) Delete(id string, forceDelete bool) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", spotMarketRequestBasePath, id)
+	var params *map[string]bool
+	if forceDelete {
+		params = &map[string]bool{"force_termination": true}
+	}
+	return s.client.DoRequest("DELETE", path, params, nil)
+}

--- a/vendor/github.com/packethost/packngo/two_factor_auth.go
+++ b/vendor/github.com/packethost/packngo/two_factor_auth.go
@@ -1,0 +1,56 @@
+package packngo
+
+const twoFactorAuthAppPath = "/user/otp/app"
+const twoFactorAuthSmsPath = "/user/otp/sms"
+
+// TwoFactorAuthService interface defines available two factor authentication functions
+type TwoFactorAuthService interface {
+	EnableApp(string) (*Response, error)
+	DisableApp(string) (*Response, error)
+	EnableSms(string) (*Response, error)
+	DisableSms(string) (*Response, error)
+	ReceiveSms() (*Response, error)
+	SeedApp() (string, *Response, error)
+}
+
+// TwoFactorAuthServiceOp implements TwoFactorAuthService
+type TwoFactorAuthServiceOp struct {
+	client *Client
+}
+
+// EnableApp function enables two factor auth using authenticatior app
+func (s *TwoFactorAuthServiceOp) EnableApp(token string) (resp *Response, err error) {
+	headers := map[string]string{"x-otp-token": token}
+	return s.client.DoRequestWithHeader("POST", headers, twoFactorAuthAppPath, nil, nil)
+}
+
+// EnableSms function enables two factor auth using sms
+func (s *TwoFactorAuthServiceOp) EnableSms(token string) (resp *Response, err error) {
+	headers := map[string]string{"x-otp-token": token}
+	return s.client.DoRequestWithHeader("POST", headers, twoFactorAuthSmsPath, nil, nil)
+}
+
+// ReceiveSms orders the auth service to issue an SMS token
+func (s *TwoFactorAuthServiceOp) ReceiveSms() (resp *Response, err error) {
+	return s.client.DoRequest("POST", twoFactorAuthSmsPath+"/receive", nil, nil)
+}
+
+// DisableApp function disables two factor auth using
+func (s *TwoFactorAuthServiceOp) DisableApp(token string) (resp *Response, err error) {
+	headers := map[string]string{"x-otp-token": token}
+	return s.client.DoRequestWithHeader("DELETE", headers, twoFactorAuthAppPath, nil, nil)
+}
+
+// DisableSms function disables two factor auth using
+func (s *TwoFactorAuthServiceOp) DisableSms(token string) (resp *Response, err error) {
+	headers := map[string]string{"x-otp-token": token}
+	return s.client.DoRequestWithHeader("DELETE", headers, twoFactorAuthSmsPath, nil, nil)
+}
+
+// SeedApp orders the auth service to issue a token via google authenticator
+func (s *TwoFactorAuthServiceOp) SeedApp() (otpURI string, resp *Response, err error) {
+	ret := &map[string]string{}
+	resp, err = s.client.DoRequest("POST", twoFactorAuthAppPath+"/receive", nil, ret)
+
+	return (*ret)["otp_uri"], resp, err
+}

--- a/vendor/github.com/packethost/packngo/user.go
+++ b/vendor/github.com/packethost/packngo/user.go
@@ -28,6 +28,7 @@ type User struct {
 	Emails                []Email `json:"emails,omitempty"`
 	PhoneNumber           string  `json:"phone_number,omitempty"`
 	URL                   string  `json:"href,omitempty"`
+	VPN                   bool    `json:"vpn"`
 }
 
 func (u User) String() string {

--- a/vendor/github.com/packethost/packngo/vpn.go
+++ b/vendor/github.com/packethost/packngo/vpn.go
@@ -1,0 +1,46 @@
+package packngo
+
+import "fmt"
+
+const vpnBasePath = "/user/vpn"
+
+// VPNConfig struct
+type VPNConfig struct {
+	Config string `json:"config,omitempty"`
+}
+
+// VPNService interface defines available VPN functions
+type VPNService interface {
+	Enable() (*Response, error)
+	Disable() (*Response, error)
+	Get(code string) (*VPNConfig, *Response, error)
+}
+
+// VPNServiceOp implements VPNService
+type VPNServiceOp struct {
+	client *Client
+}
+
+// Enable VPN for current user
+func (s *VPNServiceOp) Enable() (resp *Response, err error) {
+	return s.client.DoRequest("POST", vpnBasePath, nil, nil)
+}
+
+// Disable VPN for current user
+func (s *VPNServiceOp) Disable() (resp *Response, err error) {
+	return s.client.DoRequest("DELETE", vpnBasePath, nil, nil)
+
+}
+
+// Get returns the client vpn config for the currently logged-in user.
+func (s *VPNServiceOp) Get(code string) (config *VPNConfig, resp *Response, err error) {
+	config = &VPNConfig{}
+	path := fmt.Sprintf("%s?code=%s", vpnBasePath, code)
+
+	resp, err = s.client.DoRequest("GET", path, nil, config)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return config, resp, err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -760,10 +760,10 @@
 			"revisionTime": "2016-10-03T17:45:16Z"
 		},
 		{
-			"checksumSHA1": "CRMT2fg+XLIp7G6JLkj1PruqL0s=",
+			"checksumSHA1": "xtzttU4033dUP3TZQHBjN1oVFFU=",
 			"path": "github.com/packethost/packngo",
-			"revision": "80f62d78849dba04e42d8812329ee00558e37c5b",
-			"revisionTime": "2018-04-26T08:19:43Z",
+			"revision": "2100ba98e6dc4ca18563d91edfdbba3c4bf46ddb",
+			"revisionTime": "2018-08-29T08:31:14Z",
 			"version": "master",
 			"versionExact": "master"
 		},

--- a/website/docs/d/operating_system.html.markdown
+++ b/website/docs/d/operating_system.html.markdown
@@ -1,9 +1,9 @@
 ---
 layout: "packet"
-page_title: "Packet: opearating_system"
+page_title: "Packet: operating_system"
 sidebar_current: "docs-packet-datasource-operating-system"
 description: |-
-  Get an operationg on a Packet Operating System image
+  Get a Packet operating system image
 ---
 
 # packet\_operating\_system
@@ -20,6 +20,15 @@ data "packet_operating_system" "example" {
   provisionable_on = "baremetal_1"
 }
 
+resource "packet_device" "server" {
+  hostname         = "tf.coreos2"
+  plan             = "baremetal_1"
+  facility         = "ewr1"
+  operating_system = "${data.packet_operating_system.example.id}"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.cool_project.id}"
+}
+
 ```
 
 ## Argument Reference
@@ -31,5 +40,5 @@ data "packet_operating_system" "example" {
 
 ## Attributes Reference
 
- * `operating_system` - Opearting system of a device.
+ * `operating_system` - Operating system of a device.
 

--- a/website/docs/d/operating_system.html.markdown
+++ b/website/docs/d/operating_system.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "packet"
+page_title: "Packet: opearating_system"
+sidebar_current: "docs-packet-datasource-operating-system"
+description: |-
+  Get an operationg on a Packet Operating System image
+---
+
+# packet\_operating\_system
+
+Use this data source to get Packet Operating System image.
+
+## Example Usage
+
+```hcl
+data "packet_operating_system" "example" {
+  name             = "Container Linux"
+  distro           = "coreos"
+  version          = "alpha"
+  provisionable_on = "baremetal_1"
+}
+
+```
+
+## Argument Reference
+
+ * `distro` - (Optional) Name of the OS distribution.
+ * `name` - (Optional) Name or part of the name of the distribution. Case insensitive.
+ * `provisionable_on` - (Optional) Plan name.
+ * `version` - (Optional) Version of the distribution
+
+## Attributes Reference
+
+ * `operating_system` - Opearting system of a device.
+

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -16,6 +16,9 @@
            <li<%= sidebar_current("docs-packet-datasource-precreated-ip-block") %>>
              <a href="/docs/providers/packet/d/precreated_ip_block.html">precreated_ip_block</a>
            </li>
+           <li<%= sidebar_current("docs-packet-datasource-operating-system") %>>
+             <a href="/docs/providers/packet/d/operating_system.html">operating_system</a>
+           </li>
          </ul>
        </li>
 


### PR DESCRIPTION
Here is the new data source for packet provider.
```
make testacc TESTARGS='-run=TestAccPacketOperatingSystem_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccPacketOperatingSystem_Basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-packet        [no test files]
=== RUN   TestAccPacketOperatingSystem_Basic
--- PASS: TestAccPacketOperatingSystem_Basic (4.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-packet/packet 4.788s
```