### PR TITLE
fix broken documentation references

### DIFF
--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -119,9 +119,9 @@ The following arguments are supported:
 
 * `hostname` - (Required) The device name
 * `project_id` - (Required) The id of the project in which to create the device
-* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.net/developers/api/operatingsystems/), set your API auth token in the top of the page and see JSON from the API response.
-* `facility` - (Required) The facility in which to create the device. To find the facility code, visit [Facilities API docs](https://www.packet.net/developers/api/facilities/), set your API auth token in the top of the page and see JSON from the API response.
-* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.net/developers/api/plans/), set your auth token in the top of the page and see JSON from the API response.
+* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.net/developers/api/#operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
+* `facility` - (Required) The facility in which to create the device. To find the facility code, visit [Facilities API docs](https://www.packet.net/developers/api/#facilities), set your API auth token in the top of the page and see JSON from the API response.
+* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.net/developers/api/#plans), set your auth token in the top of the page and see JSON from the API response.
 * `billing_cycle` - (Required) monthly or hourly
 * `user_data` (Optional) - A string of the desired User Data for the device.
 * `public_ipv4_subnet_size` (Optional) - Size of allocated subnet, more

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -126,15 +126,15 @@ The following arguments are supported:
 * `user_data` (Optional) - A string of the desired User Data for the device.
 * `public_ipv4_subnet_size` (Optional) - Size of allocated subnet, more
   information is in the
-  [Custom Subnet Size](https://help.packet.net/technical/networking/custom-subnet-size) doc.
+  [Custom Subnet Size](https://help.packet.net/article/55-custom-subnet-size) doc.
 * `ipxe_script_url` (Optional) - URL pointing to a hosted iPXE script. More
   information is in the
-  [Custom iPXE](https://help.packet.net/technical/infrastructure/custom-ipxe)
+  [Custom iPXE](https://help.packet.net/article/26-custom-ipxe)
   doc.
 * `always_pxe` (Optional) - If true, a device with OS `custom_ipxe` will
   continue to boot via iPXE on reboots.
 * `hardware_reservation_id` (Optional) - The id of hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically.
-* `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://help.packet.net/technical/storage/custom-partitioning-raid) doc.
+* `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://help.packet.net/article/61-custom-partitioning-raid) doc.
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
 

--- a/website/docs/r/ip_attachment.html.markdown
+++ b/website/docs/r/ip_attachment.html.markdown
@@ -15,7 +15,7 @@ one of your reserved blocks in the same project and facility as the target devic
 
 For example, you have reserved IPv4 address block 147.229.10.152/30, you can choose to assign either the whole
 block as one subnet to a device; or 2 subnets with CIDRs 147.229.10.152/31' and 147.229.10.154/31; or 4 subnets
-with mask prefix length 32. More about the elastic IP subnets is [here](https://help.packet.net/technical/networking/elastic-ips).
+with mask prefix length 32. More about the elastic IP subnets is [here](https://help.packet.net/article/54-elastic-ips).
 
 Device and reserved block must be in the same facility.
 


### PR DESCRIPTION
Updates `help.packet.net` documentation references to use new url structure