### PR TITLE
Add resource for querying facilities

### DIFF
--- a/packet/provider.go
+++ b/packet/provider.go
@@ -35,6 +35,7 @@ func Provider() terraform.ResourceProvider {
 			"packet_ip_attachment":       resourcePacketIPAttachment(),
 			"packet_spot_market_request": resourcePacketSpotMarketRequest(),
 			"packet_vlan":                resourcePacketVlan(),
+			"packet_facility":            resourcePacketFacility(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/packet/resource_packet_facility.go
+++ b/packet/resource_packet_facility.go
@@ -1,0 +1,151 @@
+package packet
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/packethost/packngo"
+)
+
+func resourcePacketFacility() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePacketFacilityCreate,
+		Read:   resourcePacketFacilityRead,
+		Delete: schema.RemoveFromState,
+		Schema: map[string]*schema.Schema{
+			"keepers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+			"slugs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"features": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+				MinItems: 1,
+				Optional: true,
+			},
+			"plan": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice(packngo.DevicePlans, false),
+			},
+			"utilization": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(packngo.UtilizationLevels, false),
+				ForceNew:     true,
+			},
+		},
+	}
+}
+
+func filterOnPlan(slugs []string, cr *packngo.CapacityReport, plan string) []string {
+	r := []string{}
+
+	for f, planMap := range *cr {
+		if _, ok := planMap[plan]; ok {
+			r = append(r, f)
+			continue
+		}
+	}
+	return r
+}
+
+func findStr(a []string, x string) int {
+	for i, n := range a {
+		if x == n {
+			return i
+		}
+	}
+	return len(a)
+}
+
+func filterOnUtilization(slugs []string, cr *packngo.CapacityReport, plan, u string) []string {
+	r := []string{}
+	desiredIx := findStr(packngo.UtilizationLevels, u)
+
+	for f, planMap := range *cr {
+		for p, planUtilization := range planMap {
+			if p != plan {
+				continue
+			}
+			ix := findStr(packngo.UtilizationLevels, planUtilization.Level)
+			if ix >= desiredIx {
+				r = append(r, f)
+				break
+			}
+		}
+	}
+	return r
+}
+func resourcePacketFacilityCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	pIf, planFilter := d.GetOk("plan")
+	plan := pIf.(string)
+	uIf, utilizationFilter := d.GetOk("utilization")
+	utilization := uIf.(string)
+	fIf, featuresFilter := d.GetOk("features")
+	featureSet := fIf.(*schema.Set)
+	featureSlice := convertStringArr(featureSet.List())
+
+	if featuresFilter {
+		for _, f := range featureSlice {
+			if !contains(packngo.FacilityFeatures, f) {
+				return fmt.Errorf("%q is not a valid Packet facility feature, only %+v are allowed", f, packngo.FacilityFeatures)
+			}
+		}
+	}
+
+	if utilizationFilter && !planFilter {
+		return friendlyError(fmt.Errorf("If you set utilization, you also must set plan"))
+	}
+
+	slugs := []string{}
+
+	fl, _, err := client.Facilities.List(nil)
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	for _, f := range fl {
+		if featuresFilter {
+			currentFacFeatureSet := schema.NewSet(
+				featureSet.F, convertInterfaceArr(f.Features))
+
+			diff := featureSet.Difference(currentFacFeatureSet)
+
+			if diff.Len() > 0 {
+				continue
+			}
+		}
+		slugs = append(slugs, f.Code)
+	}
+
+	if (utilizationFilter || planFilter) && (len(slugs) > 0) {
+		capList, _, err := client.CapacityService.List()
+		if err != nil {
+			return friendlyError(err)
+		}
+		slugs = filterOnPlan(slugs, capList, plan)
+		if utilizationFilter {
+			slugs = filterOnUtilization(slugs, capList, plan, utilization)
+		}
+	}
+
+	d.Set("slugs", slugs)
+	d.SetId(time.Now().UTC().String())
+	return nil
+}
+
+func resourcePacketFacilityRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/packet/resource_packet_facility_test.go
+++ b/packet/resource_packet_facility_test.go
@@ -1,0 +1,93 @@
+package packet
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPacketFacility_Basic(t *testing.T) {
+	totalFacs := new(int)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: `resource "packet_facility" "test" {}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFacility("packet_facility.test", totalFacs),
+				),
+			},
+			resource.TestStep{
+				Config: `resource "packet_facility" "test2" { features = ["storage", "global_ipv4"] }`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFacilityLessThan("packet_facility.test2", totalFacs),
+				),
+			},
+		},
+	})
+}
+
+func checkFacilitiesAndGetCount(s *terraform.State, res string) (error, int) {
+	rs, ok := s.RootModule().Resources[res]
+	if !ok {
+		return fmt.Errorf("Can't find facility resource: %s", res), 0
+	}
+
+	if rs.Primary.ID == "" {
+		return errors.New("facilities resource ID not set."), 0
+	}
+
+	countStr, ok := rs.Primary.Attributes["slugs.#"]
+	if !ok {
+		return fmt.Errorf("can't find 'slugs' attribute"), 0
+	}
+
+	count, err := strconv.Atoi(countStr)
+	if err != nil {
+		return errors.New("failed to read number of facilities"), 0
+	}
+	if count == 0 {
+		return fmt.Errorf("expected some facilities listed, this is most likely a bug"), 0
+	}
+	for i := 0; i < count; i++ {
+		idx := "slugs." + strconv.Itoa(i)
+		v, ok := rs.Primary.Attributes[idx]
+		if !ok {
+			return fmt.Errorf("facilities list is corrupt (%q not found), this is definitely a bug", idx), 0
+		}
+		if len(v) < 1 {
+			return fmt.Errorf("Empty facility slug (%q), this is definitely a bug", idx), 0
+		}
+	}
+	return nil, count
+
+}
+
+func testAccCheckFacilityLessThan(res string, total *int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		err, count := checkFacilitiesAndGetCount(s, res)
+		if err != nil {
+			return err
+		}
+		if count >= *total {
+			return fmt.Errorf("%q should filter out some facilities, and the total should be less than %d, but is %d", res, *total, count)
+		}
+		return nil
+	}
+}
+
+func testAccCheckFacility(res string, total *int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		err, count := checkFacilitiesAndGetCount(s, res)
+		if err != nil {
+			return err
+		}
+		*total = count
+		return nil
+	}
+}

--- a/packet/utils.go
+++ b/packet/utils.go
@@ -19,3 +19,11 @@ func convertStringArr(ifaceArr []interface{}) []string {
 	}
 	return arr
 }
+
+func convertInterfaceArr(a []string) []interface{} {
+	var r []interface{}
+	for _, v := range a {
+		r = append(r, v)
+	}
+	return r
+}

--- a/website/docs/r/facility.markdown
+++ b/website/docs/r/facility.markdown
@@ -1,0 +1,58 @@
+---
+layout: "packet"
+page_title: "Packet: facility"
+sidebar_current: "docs-packet-resource-facility"
+description: |-
+  Select Packet Facilities
+---
+
+# packet\_facility
+
+Use this resource to select facilities in the Packet Host. You can filter them by several criteria: features, plan and utilization level.
+
+This resource has the `keepers` param in the same manner as the (random resources)[https://www.terraform.io/docs/providers/random/index.html#resource-quot-keepers-quot-].
+
+All the arguments are optional, if you don't set them, all the facilities will be returned in the `slugs` attribute.
+
+## Example Usage
+
+```hcl
+# create baremetal_0 device in a facility where Global IPv4 is available.
+
+locals {
+    plan = "baremetal_0"
+}
+
+resource "packet_facility" "example_facility" {
+  plan             = "${local.plan}"
+  features         = ["global_ipv4"]
+  keepers       {
+    when = "2018-12-15"
+  }
+}
+
+resource "packet_project" "cool_project" {
+  name             = "cool-project"
+}
+
+resource "packet_device" "server" {
+  hostname         = "tftest"
+  plan             = "${local.plan}"
+  facility         = "${packet_facility.example_facility.slugs.0}"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.cool_project.id}"
+}
+```
+
+## Argument Reference
+
+ * `features` - (Optional) Only return facilities with features listed in this array. Possible items are `"baremetal", "layer_2", "backend_transfer", "storage", "global_ipv4"`.
+ * `plan` - (Optional) Only return facilities where this plan is available. The plan slugs can be found out from (the API docs)[https://www.packet.com/developers/api/#plans]. Set your auth token in the top of the page and see JSON from the API response. 
+ * `utilization` - (Optional) The highest utilization level for a plan (set in the other argument) that you accept. Possible values are `"unavailable", "critical", "limited", "normal"`. E.g. if you set this to `"critical"`, only facilities where the selected plan utilization is `"critical", "limited"` and `"normal"` will be returned.
+ * `keepers` - (Optional) Key-value pair which should be selected so that they remain the same, until the API should be queried for the facilities again.
+
+## Attributes Reference
+
+ * `slugs` - Array of facilitiy slugs selected by criteria.
+

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -61,6 +61,9 @@
             <li<%= sidebar_current("docs-packet-resource-vlan") %>>
               <a href="/docs/providers/packet/r/vlan.html">packet_vlan</a>
             </li>
+            <li<%= sidebar_current("docs-packet-resource-facility") %>>
+             <a href="/docs/providers/packet/r/facility.html">facility</a>
+           </li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
This PR adds a resource for querying facilities, in order to allow users to take advantage of the facility features from the API; and to select facility automatically.

This is a rework of dynamic "region" selection functionality. It addresses:
- a previous PR, where dynamic selection of facilities on device creation was refused by @radeksimko - https://github.com/terraform-providers/terraform-provider-packet/pull/76#pullrequestreview-179394967
- consultation with @tombuildsstuff in the TF-committers Slack channel

The new resource is a query much like https://www.terraform.io/docs/providers/random/r/string.html  rather than an item in the API. I decided not to do it as a datasource, because of the utilization level filter - utilization of datacenters will vary and the facility query should be executed only on argument change - that's why it offers the `keepers` attr, like the random\_ resources.

It closes #32 and #80.

