### PR TITLE
BGP support: extend project by BGP Config, new resource for BGP session

### DIFF
--- a/packet/provider.go
+++ b/packet/provider.go
@@ -35,6 +35,7 @@ func Provider() terraform.ResourceProvider {
 			"packet_ip_attachment":       resourcePacketIPAttachment(),
 			"packet_spot_market_request": resourcePacketSpotMarketRequest(),
 			"packet_vlan":                resourcePacketVlan(),
+			"packet_bgp_session":         resourcePacketBGPSession(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/packet/resource_packet_bgp_session.go
+++ b/packet/resource_packet_bgp_session.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/packethost/packngo"
 )
 
@@ -23,9 +24,10 @@ func resourcePacketBGPSession() *schema.Resource {
 				ForceNew: true,
 			},
 			"address_family": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ipv4", "ipv6"}, false),
 			},
 
 			"status": {
@@ -56,6 +58,10 @@ func resourcePacketBGPSessionRead(d *schema.ResourceData, meta interface{}) erro
 	bgpSession, _, err := client.BGPSessions.Get(d.Id(),
 		&packngo.GetOptions{Includes: []string{"device"}})
 	if err != nil {
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.Set("device_id", bgpSession.Device.ID)

--- a/packet/resource_packet_bgp_session.go
+++ b/packet/resource_packet_bgp_session.go
@@ -1,0 +1,75 @@
+package packet
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func resourcePacketBGPSession() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePacketBGPSessionCreate,
+		Read:   resourcePacketBGPSessionRead,
+		Delete: resourcePacketBGPSessionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"address_family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePacketBGPSessionCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	dID := d.Get("device_id").(string)
+	addressFamily := d.Get("address_family").(string)
+	log.Printf("[DEBUG] creating %s BGP session to device (%s)\n", addressFamily, dID)
+	bgpSession, _, err := client.BGPSessions.Create(
+		dID, packngo.CreateBGPSessionRequest{AddressFamily: "ipv4"})
+	if err != nil {
+		return friendlyError(err)
+	}
+
+	d.SetId(bgpSession.ID)
+	return resourcePacketBGPSessionRead(d, meta)
+}
+
+func resourcePacketBGPSessionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	bgpSession, _, err := client.BGPSessions.Get(d.Id(),
+		&packngo.GetOptions{Includes: []string{"device"}})
+	if err != nil {
+		return err
+	}
+	d.Set("device_id", bgpSession.Device.ID)
+	d.Set("address_family", bgpSession.AddressFamily)
+	d.Set("status", bgpSession.Status)
+	d.SetId(bgpSession.ID)
+	return nil
+}
+
+func resourcePacketBGPSessionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	_, err := client.BGPSessions.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -1,0 +1,77 @@
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/packethost/packngo"
+)
+
+func TestAccPacketBGPSession_Basic(t *testing.T) {
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketBGPSessionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPacketBGPSessionConfig_basic(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"packet_device.test", "id",
+						"packet_bgp_session.test", "device_id"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "packet_bgp_session.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckPacketBGPSessionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*packngo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "packet_bgp_session" {
+			continue
+		}
+		if _, _, err := client.BGPSessions.Get(rs.Primary.ID, nil); err == nil {
+			return fmt.Errorf("BGPSession still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckPacketBGPSessionConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "packet_project" "test" {
+    name = "%s"
+	bgp_config {
+		deployment_type = "local"
+		md5 = "C179c28c41a85b"
+		asn = 65000
+	}
+}
+
+resource "packet_device" "test" {
+    hostname         = "terraform-test-bgp-sesh"
+    plan             = "baremetal_0"
+    facility         = "ewr1"
+    operating_system = "ubuntu_16_04"
+    billing_cycle    = "hourly"
+    project_id       = "${packet_project.test.id}"
+}
+
+resource "packet_bgp_session" "test" {
+	device_id = "${packet_device.test.id}"
+	address_family = "ipv4"
+}`, name)
+}

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -57,8 +57,53 @@ func resourcePacketProject() *schema.Resource {
 				},
 				ValidateFunc: validation.StringMatch(uuidRE, "must be a valid UUID"),
 			},
+			"bgp_config": &schema.Schema{
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deployment_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"asn": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"md5": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"status": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_object": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_prefix": &schema.Schema{
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
+}
+
+func expandBGPConfig(d *schema.ResourceData) packngo.CreateBGPConfigRequest {
+	bgpCreateRequest := packngo.CreateBGPConfigRequest{
+		DeploymentType: d.Get("bgp_config.0.deployment_type").(string),
+		Asn:            d.Get("bgp_config.0.asn").(int),
+		Md5:            d.Get("bgp_config.0.md5").(string),
+	}
+	return bgpCreateRequest
+
 }
 
 func resourcePacketProjectCreate(d *schema.ResourceData, meta interface{}) error {
@@ -76,6 +121,25 @@ func resourcePacketProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(project.ID)
 
+	if _, ok := d.GetOk("bgp_config"); !ok {
+		d.Set("bgp_config", []interface{}{})
+	} else {
+
+		bgpCreateRequest := expandBGPConfig(d)
+		_, err := client.BGPConfig.Create(project.ID, bgpCreateRequest)
+		if err != nil {
+			return friendlyError(err)
+		}
+	}
+
+	_, hasBGPConfig := d.GetOk("bgp_config")
+	if hasBGPConfig {
+		bgpCR := expandBGPConfig(d)
+		_, err := client.BGPConfig.Create(project.ID, bgpCR)
+		if err != nil {
+			return friendlyError(err)
+		}
+	}
 	return resourcePacketProjectRead(d, meta)
 }
 
@@ -96,14 +160,70 @@ func resourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.Set("id", proj.ID)
-	d.Set("payment_method_id", path.Base(proj.PaymentMethod.URL))
-	d.Set("name", proj.Name)
-	d.Set("organization_id", path.Base(proj.Organization.URL))
-	d.Set("created", proj.Created)
-	d.Set("updated", proj.Updated)
+	d.Partial(true)
 
+	d.SetId(proj.ID)
+	d.Set("payment_method_id", path.Base(proj.PaymentMethod.URL))
+	d.SetPartial("payment_method_id")
+	d.Set("name", proj.Name)
+	d.SetPartial("name")
+	d.Set("organization_id", path.Base(proj.Organization.URL))
+	d.SetPartial("organization_id")
+	d.Set("created", proj.Created)
+	d.SetPartial("created")
+	d.Set("updated", proj.Updated)
+	d.SetPartial("updated")
+
+	bgpConf, _, err := client.BGPConfig.Get(proj.ID, nil)
+	if err != nil {
+		err = friendlyError(err)
+		return err
+	}
+	if bgpConf != nil {
+		// guard against an empty struct
+		if bgpConf.ID != "" {
+			err := d.Set("bgp_config", flattenBGPConfig(bgpConf))
+			if err != nil {
+				err = friendlyError(err)
+				return err
+			}
+		}
+	}
+	d.Partial(false)
 	return nil
+}
+
+func flattenBGPConfig(l *packngo.BGPConfig) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, 1)
+
+	if l == nil {
+		return nil
+	}
+
+	r := make(map[string]interface{})
+
+	if l.Status != "" {
+		r["status"] = l.Status
+	}
+	if l.DeploymentType != "" {
+		r["deployment_type"] = l.DeploymentType
+	}
+	if l.RouteObject != "" {
+		r["route_object"] = l.RouteObject
+	}
+	if l.Md5 != "" {
+		r["md5"] = l.Md5
+	}
+	if l.Asn != 0 {
+		r["asn"] = l.Asn
+	}
+	if l.MaxPrefix != 0 {
+		r["max_prefix"] = l.MaxPrefix
+	}
+
+	result = append(result, r)
+
+	return result
 }
 
 func resourcePacketProjectUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -62,7 +62,6 @@ func resourcePacketProject() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
-				ForceNew: false,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"deployment_type": &schema.Schema{

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -81,10 +81,6 @@ func resourcePacketProject() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"route_object": &schema.Schema{
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"max_prefix": &schema.Schema{
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -207,9 +203,6 @@ func flattenBGPConfig(l *packngo.BGPConfig) []map[string]interface{} {
 	}
 	if l.DeploymentType != "" {
 		r["deployment_type"] = l.DeploymentType
-	}
-	if l.RouteObject != "" {
-		r["route_object"] = l.RouteObject
 	}
 	if l.Md5 != "" {
 		r["md5"] = l.Md5

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -156,26 +156,17 @@ func resourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.Partial(true)
-
 	d.SetId(proj.ID)
 	d.Set("payment_method_id", path.Base(proj.PaymentMethod.URL))
-	d.SetPartial("payment_method_id")
 	d.Set("name", proj.Name)
-	d.SetPartial("name")
 	d.Set("organization_id", path.Base(proj.Organization.URL))
-	d.SetPartial("organization_id")
 	d.Set("created", proj.Created)
-	d.SetPartial("created")
 	d.Set("updated", proj.Updated)
-	d.SetPartial("updated")
 
 	bgpConf, _, err := client.BGPConfig.Get(proj.ID, nil)
-	if err != nil {
-		err = friendlyError(err)
-		return err
-	}
-	if bgpConf != nil {
+	d.Set("bgp_config", []interface{}{})
+
+	if (err == nil) && (bgpConf != nil) {
 		// guard against an empty struct
 		if bgpConf.ID != "" {
 			err := d.Set("bgp_config", flattenBGPConfig(bgpConf))
@@ -185,7 +176,6 @@ func resourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-	d.Partial(false)
 	return nil
 }
 

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -31,6 +31,28 @@ func TestAccPacketProject_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPacketProject_BGP(t *testing.T) {
+	var project packngo.Project
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketProjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPacketProjectConfig_BGP(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketProjectExists("packet_project.foobar", &project),
+					resource.TestCheckResourceAttr(
+						"packet_project.foobar", "bgp_config.0.md5",
+						"C179c28c41a85b"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPacketProject_Update(t *testing.T) {
 	var project packngo.Project
 	rInt := acctest.RandInt()
@@ -104,6 +126,18 @@ func testAccCheckPacketProjectConfig_basic(r int) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
     name = "foobar-%d"
+}`, r)
+}
+
+func testAccCheckPacketProjectConfig_BGP(r int) string {
+	return fmt.Sprintf(`
+resource "packet_project" "foobar" {
+    name = "foobar-%d"
+	bgp_config {
+		deployment_type = "local"
+		md5 = "C179c28c41a85b"
+		asn = 65000
+	}
 }`, r)
 }
 

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -32,7 +32,7 @@ func TestAccPacketProject_Basic(t *testing.T) {
 	})
 }
 
-func TestAccPacketProject_BGP(t *testing.T) {
+func TestAccPacketProject_BGPBasic(t *testing.T) {
 	var project packngo.Project
 	rInt := acctest.RandInt()
 
@@ -42,12 +42,12 @@ func TestAccPacketProject_BGP(t *testing.T) {
 		CheckDestroy: testAccCheckPacketProjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPacketProjectConfig_BGP(rInt, "2SFsdfsg43)"),
+				Config: testAccCheckPacketProjectConfig_BGP(rInt, "2SFsdfsg43"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),
 					resource.TestCheckResourceAttr(
 						"packet_project.foobar", "bgp_config.0.md5",
-						"C179c28c41a85b"),
+						"2SFsdfsg43"),
 				),
 			},
 		},
@@ -114,6 +114,7 @@ func TestAccPacketProject_BGPUpdate(t *testing.T) {
 				Config: testAccCheckPacketProjectConfig_BGP(rInt, "fdsfsdf432F"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists(res, &p2),
+					resource.TestCheckResourceAttr(res, "bgp_config.0.md5", "fdsfsdf432F"),
 					testAccCheckPacketSameProject(t, &p1, &p2),
 				),
 			},
@@ -121,6 +122,7 @@ func TestAccPacketProject_BGPUpdate(t *testing.T) {
 				Config: testAccCheckPacketProjectConfig_BGP(rInt, "fdsfsdf432G"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists(res, &p3),
+					resource.TestCheckResourceAttr(res, "bgp_config.0.md5", "fdsfsdf432G"),
 					testAccCheckPacketSameProject(t, &p2, &p3),
 				),
 			},

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -2,6 +2,7 @@ package packet
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -41,7 +42,7 @@ func TestAccPacketProject_BGP(t *testing.T) {
 		CheckDestroy: testAccCheckPacketProjectDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPacketProjectConfig_BGP(rInt),
+				Config: testAccCheckPacketProjectConfig_BGP(rInt, "2SFsdfsg43)"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),
 					resource.TestCheckResourceAttr(
@@ -81,6 +82,56 @@ func TestAccPacketProject_Update(t *testing.T) {
 		},
 	})
 }
+
+func testAccCheckPacketSameProject(t *testing.T, before, after *packngo.Project) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before.ID != after.ID {
+			t.Fatalf("Expected device to be the same, but it was recreated: %s -> %s", before.ID, after.ID)
+		}
+		return nil
+	}
+}
+
+func TestAccPacketProject_BGPUpdate(t *testing.T) {
+	var p1, p2, p3 packngo.Project
+	rInt := acctest.RandInt()
+	res := "packet_project.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPacketProjectConfig_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketProjectExists(res, &p1),
+					resource.TestCheckResourceAttr(res, "name",
+						fmt.Sprintf("foobar-%d", rInt)),
+				),
+			},
+			{
+				Config: testAccCheckPacketProjectConfig_BGP(rInt, "fdsfsdf432F"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketProjectExists(res, &p2),
+					testAccCheckPacketSameProject(t, &p1, &p2),
+				),
+			},
+			{
+				Config: testAccCheckPacketProjectConfig_BGP(rInt, "fdsfsdf432G"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketProjectExists(res, &p3),
+					testAccCheckPacketSameProject(t, &p2, &p3),
+				),
+			},
+			{
+				Config:      testAccCheckPacketProjectConfig_basic(rInt),
+				ExpectError: regexp.MustCompile("can not be removed"),
+			},
+		},
+	})
+}
+
 func testAccCheckPacketProjectDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*packngo.Client)
 
@@ -129,16 +180,16 @@ resource "packet_project" "foobar" {
 }`, r)
 }
 
-func testAccCheckPacketProjectConfig_BGP(r int) string {
+func testAccCheckPacketProjectConfig_BGP(r int, pass string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
     name = "foobar-%d"
 	bgp_config {
 		deployment_type = "local"
-		md5 = "C179c28c41a85b"
+		md5 = "%s"
 		asn = 65000
 	}
-}`, r)
+}`, r, pass)
 }
 
 func testAccCheckPacketProjectOrgConfig(r string) string {

--- a/website/docs/r/bgp_session.html.markdown
+++ b/website/docs/r/bgp_session.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "packet"
+page_title: "Packet: packet_bgp_session"
+sidebar_current: "docs-packet-resource-bgp-session"
+description: |-
+  BGP session in Packet Host
+---
+
+# packet\_bgp\_session
+
+Provides a resource to manage BGP session in Packet Host. Refer to [Packet BGP documentation](https://support.packet.com/kb/articles/bgp) for more details.
+
+You need to have BGP config enabled in your project.
+
+BGP session must be linked to a device running BIRD or other BGP routing client which will control route advertisements via the session to Packet's upstream routers. 
+
+## Example Usage
+
+```hcl
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `device_id` - (Required) ID of device to which to assign the subnet
+* `cidr_notation` - (Required) CIDR notation of subnet from block reserved in the same
+  project and facility as the device
+
+## Attributes Reference
+
+The following attributes are exported:
+* `route_object`: Specifies AS-MACRO to use when building client route filters (as opposed to AS number and read only)
+* `ranges`: The IP block ranges associated to your ASN (only populated in global BGP)
+* `max_prefix`: The maximum number of route filters allowed per server

--- a/website/docs/r/bgp_session.html.markdown
+++ b/website/docs/r/bgp_session.html.markdown
@@ -6,31 +6,163 @@ description: |-
   BGP session in Packet Host
 ---
 
-# packet\_bgp\_session
+# packet_bgp_session
 
-Provides a resource to manage BGP session in Packet Host. Refer to [Packet BGP documentation](https://support.packet.com/kb/articles/bgp) for more details.
+Provides a resource to manage BGP sessions in Packet Host. Refer to [Packet BGP documentation](https://support.packet.com/kb/articles/bgp) for more details.
 
 You need to have BGP config enabled in your project.
 
-BGP session must be linked to a device running BIRD or other BGP routing client which will control route advertisements via the session to Packet's upstream routers. 
+BGP session must be linked to a device running [BIRD](https://bird.network.cz) or other BGP routing daemon which will control route advertisements via the session to Packet's upstream routers. 
 
 ## Example Usage
 
-```hcl
+Following HCL illustrates usage of the BGP features in Packet. It will 
 
+* spawn a device in a new BGP-enabled project
+* reserve a floating IPv4 address in the project in the same location as the device
+* configure the floating IPv4 statically in the device
+* install and configure [BIRD](https://bird.network.cz) in the device, and make it announce the floating IPv4 locally
+
+```hcl
+variable "bgp_password" {
+    type = "string"
+    default = "955dB0b81Ef"
+
+}
+
+resource "packet_project" "test" {
+    name = "testpro"
+    bgp_config {
+        deployment_type = "local"
+        md5 = "${var.bgp_password}"
+        asn = 65000
+    }
+}
+
+resource "packet_reserved_ip_block" "addr" {
+    project_id = "${packet_project.test.id}"
+    facility = "ewr1"
+    quantity = 1
+}
+
+resource "packet_device" "test" {
+    hostname         = "terraform-test-bgp-sesh"
+    plan             = "baremetal_0"
+    facility         = "ewr1"
+    operating_system = "ubuntu_16_04"
+    billing_cycle    = "hourly"
+    project_id       = "${packet_project.test.id}"
+}
+
+resource "packet_bgp_session" "test" {
+	device_id = "${packet_device.test.id}"
+	address_family = "ipv4"
+}
+
+
+data "template_file" "interface_lo0" {
+
+    template = <<EOF
+auto lo:0
+iface lo:0 inet static
+   address $${floating_ip}
+   netmask $${floating_netmask}
+EOF
+
+    vars = {
+        floating_ip       = "${packet_reserved_ip_block.addr.address}"
+        floating_netmask  = "${packet_reserved_ip_block.addr.netmask}"
+    }
+}
+
+data "template_file" "bird_conf_template" {
+
+    template = <<EOF
+filter packet_bgp {
+    if net = $${floating_ip}/$${floating_cidr} then accept;
+}
+router id $${private_ipv4};
+protocol direct {
+    interface "lo";
+}
+protocol kernel {
+    scan time 10;
+    persist;
+    import all;
+    export all;
+}
+protocol device {
+    scan time 10;
+}
+protocol bgp {
+    export filter packet_bgp;
+    local as 65000;
+    neighbor $${gateway_ip} as 65530;
+    password "$${bgp_password}"; 
+}
+EOF
+
+    vars = {
+        floating_ip    = "${packet_reserved_ip_block.addr.address}"
+        floating_cidr  = "${packet_reserved_ip_block.addr.cidr}"
+        private_ipv4   = "${packet_device.test.network.0.address}"
+        gateway_ip     = "${packet_device.test.network.0.gateway}"
+        bgp_password   = "${var.bgp_password}"
+    }
+}
+
+resource "null_resource" "configure_bird" {
+
+    connection {
+        type = "ssh"
+        host = "${packet_device.test.access_public_ipv4}"
+        private_key = "${file("/home/tomk/keys/tkarasek_key.pem")}"
+        agent = false
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "apt-get install bird",
+            "mv /etc/bird/bird.conf /etc/bird/bird.conf.old",
+        ]
+    }
+
+    triggers = {
+        template = "${data.template_file.bird_conf_template.rendered}"
+        template = "${data.template_file.interface_lo0.rendered}"
+    }
+
+    provisioner "file" {
+        content     = "${data.template_file.bird_conf_template.rendered}"
+        destination = "/etc/bird/bird.conf"
+    }
+
+    provisioner "file" {
+        content     = "${data.template_file.interface_lo0.rendered}"
+        destination = "/etc/network/interfaces.d/lo0"
+    }
+
+    provisioner "remote-exec" {
+        inline = [
+            "sysctl net.ipv4.ip_forward=1",
+            "grep /etc/network/interfaces.d /etc/network/interfaces || echo 'source /etc/network/interfaces.d/*' >> /etc/network/interfaces",
+            "ifup lo:0",
+            "service bird restart",
+        ]
+    }
+
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `device_id` - (Required) ID of device to which to assign the subnet
-* `cidr_notation` - (Required) CIDR notation of subnet from block reserved in the same
-  project and facility as the device
+* `device_id` - (Required) ID of device 
+* `address_family` - `ipv4` or `ipv6`
 
 ## Attributes Reference
 
 The following attributes are exported:
-* `route_object`: Specifies AS-MACRO to use when building client route filters (as opposed to AS number and read only)
-* `ranges`: The IP block ranges associated to your ASN (only populated in global BGP)
-* `max_prefix`: The maximum number of route filters allowed per server
+
+* `status`: Status of the session - `up` or `down`

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -20,6 +20,19 @@ resource "packet_project" "tf_project_1" {
 }
 ```
 
+Example with BGP config
+```hcl
+# Create a new Project
+resource "packet_project" "tf_project_1" {
+  name           = "tftest"
+  bgp_config {
+    deployment_type = "local"
+    md5 = "C179c28c41a85b"
+    asn = 65000
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -27,6 +40,12 @@ The following arguments are supported:
 * `name` - (Required) The name of the Project on Packet.net
 * `payment_method_id` - The UUID of payment method for this project. If you keep it empty, Packet API will pick your default Payment Method.
 * `organization_id` - The UUID of Organization under which you want to create the project. If you leave it out, the project will be create under your the default Organization of your account.
+* bgp_config - Optional BGP settings. Refer to [Packet guide for BGP](https://support.packet.com/kb/articles/bgp).
+
+The `bgp_config` block supports:
+* `asn` - Autonomous System Numer for local BGP deployment
+* `md5` - (Optional) MD5 sum of password for BGP session
+* `deployment_type` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Packet engineers
 
 ## Attributes Reference
 
@@ -37,3 +56,10 @@ The following attributes are exported:
 * `organization_id` - The UUID of this project's parent organization.
 * `created` - The timestamp for when the Project was created
 * `updated` - The timestamp for the last time the Project was updated
+
+The `bgp_config` block additionally exports: 
+* `status` - status of BGP configuration in the project
+* `max_prefix` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Packet engineers
+* `route_object`
+* `ranges`
+* `max_prefix`

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -42,6 +42,8 @@ The following arguments are supported:
 * `organization_id` - The UUID of Organization under which you want to create the project. If you leave it out, the project will be create under your the default Organization of your account.
 * bgp_config - Optional BGP settings. Refer to [Packet guide for BGP](https://support.packet.com/kb/articles/bgp).
 
+Once you set the BGP config in a project, it can't be removed (due to a limitation in the Packet API). It can be updated.
+
 The `bgp_config` block supports:
 * `asn` - Autonomous System Numer for local BGP deployment
 * `md5` - (Optional) Password for BGP session in plaintext (not a checksum)

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 The `bgp_config` block supports:
 * `asn` - Autonomous System Numer for local BGP deployment
-* `md5` - (Optional) MD5 sum of password for BGP session
+* `md5` - (Optional) Password for BGP session in plaintext (not a checksum)
 * `deployment_type` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Packet engineers
 
 ## Attributes Reference
@@ -59,7 +59,4 @@ The following attributes are exported:
 
 The `bgp_config` block additionally exports: 
 * `status` - status of BGP configuration in the project
-* `max_prefix` - `private` or `public`, the `private` is likely to be usable immediately, the `public` will need to be review by Packet engineers
-* `route_object`
-* `ranges`
-* `max_prefix`
+* `max_prefix` - The maximum number of route filters allowed per server


### PR DESCRIPTION
This PR will add support for BGP networking API resources as decribed in https://help.packet.net/article/56-bgp

Ready for review.

The usage is illustrated in the bgp_session resource doc.

