### PR TITLE
Hotfix of network attribute order for packet_device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.4.0 (Unreleased)
+## 1.3.1 (Unreleased)
+
+IMPROVEMENTS:
+
+- [#92](https://github.com/terraform-providers/terraform-provider-packet/pull/92) Hotfix of device network order, back to: 0. Public IPv4, 1. IPv6, 2. Private IPv4
+
 ## 1.3.0 (February 01, 2019)
 
 FEATURES:

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -385,11 +385,11 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 
 func getNetworkRank(family int, public bool) int {
 	switch {
-	case family == 4 && !public:
-		return 0
 	case family == 4 && public:
-		return 1
+		return 0
 	case family == 6:
+		return 1
+	case family == 4 && public:
 		return 2
 	}
 	return 3

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -286,19 +286,19 @@ func testAccCheckPacketDeviceNetworkOrder(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", n)
 		}
 		if rs.Primary.Attributes["network.0.family"] != "4" {
-			return fmt.Errorf("first netowrk should be private IPv4")
-		}
-		if rs.Primary.Attributes["network.0.public"] == "true" {
-			return fmt.Errorf("first netowrk should be private IPv4")
-		}
-		if rs.Primary.Attributes["network.1.family"] != "4" {
-			return fmt.Errorf("second netowrk should be public IPv4")
-		}
-		if rs.Primary.Attributes["network.1.public"] == "false" {
 			return fmt.Errorf("first netowrk should be public IPv4")
 		}
-		if rs.Primary.Attributes["network.2.family"] != "6" {
+		if rs.Primary.Attributes["network.0.public"] != "true" {
+			return fmt.Errorf("first netowrk should be public IPv4")
+		}
+		if rs.Primary.Attributes["network.1.family"] != "6" {
 			return fmt.Errorf("second netowrk should be public IPv6")
+		}
+		if rs.Primary.Attributes["network.2.family"] != "4" {
+			return fmt.Errorf("third netowrk should be private IPv4")
+		}
+		if rs.Primary.Attributes["network.2.public"] == "true" {
+			return fmt.Errorf("third netowrk should be private IPv4")
 		}
 		return nil
 	}

--- a/website/docs/r/bgp_session.html.markdown
+++ b/website/docs/r/bgp_session.html.markdown
@@ -105,8 +105,8 @@ EOF
     vars = {
         floating_ip    = "${packet_reserved_ip_block.addr.address}"
         floating_cidr  = "${packet_reserved_ip_block.addr.cidr}"
-        private_ipv4   = "${packet_device.test.network.0.address}"
-        gateway_ip     = "${packet_device.test.network.0.gateway}"
+        private_ipv4   = "${packet_device.test.network.2.address}"
+        gateway_ip     = "${packet_device.test.network.2.gateway}"
         bgp_password   = "${var.bgp_password}"
     }
 }

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -147,11 +147,16 @@ The following attributes are exported:
 * `project_id`- The ID of the project the device belongs to
 * `facility` - The facility the device is in
 * `plan` - The hardware config of the device
-* `network` - The device's private and public IP (v4 and v6) network details. When a device is run without any special network configuration, it will have 3 newtworks: private IPv4, public IPv4 and an IPv6 in this order. The fields of the network attribute are:
+* `network` - The device's private and public IP (v4 and v6) network details. When a device is run without any special network configuration, it will have 3 networks: 
+  * Public IPv4 at `packet_device.name.network.0`
+  * IPv6 at `packet_device.name.network.1`
+  * Private IPv4 at `packet_device.name.network.2`
+  Elastic addresses then stack by type - an assigned public IPv4 will go after the management public IPv4 (to index 1), and will then shift the indices of the IPv6 and private IPv4. Assigned private IPv4 will go after the management private IPv4 (to the end of the network list).
+  The fields of the network attributes are:
   * `address` - IPv4 or IPv6 address string
   * `cidr` - bit length of the network mask of the address
   * `gateway` - address of router
-  * `public` - whether address is routable from the Internet
+  * `public` - whether the address is routable from the Internet
   * `family` - IP version - "4" or "6"
  
 * `access_public_ipv6` - The ipv6 maintenance IP assigned to the device


### PR DESCRIPTION
I have changed the order of the elements in the network List attribute in #89. It was not a great idea considering how many users depend on the implicit order of the network configuration:

https://github.com/search?p=2&q=%22network.0.address%22+ssh+packet+terraform&type=Code

This PR reverts the order of the items in the network, so that it's like before, i.e.

0. Public IPv4
1. IPv6
2. Private IPv4

plus documentation.