### PR TITLE
allow list of facilities for packet_device

### DIFF
--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -16,6 +16,26 @@ import (
 var matchErrMustBeProvided = regexp.MustCompile(".* must be provided when .*")
 var matchErrShouldNotBeAnIPXE = regexp.MustCompile(`.*"user_data" should not be an iPXE.*`)
 
+func TestAccPacketDevice_FacilityList(t *testing.T) {
+	var device packngo.Device
+	rs := acctest.RandString(10)
+	r := "packet_device.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketDeviceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPacketDeviceConfig_facility_list(rs),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketDeviceExists(r, &device),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPacketDevice_NetworkOrder(t *testing.T) {
 	var device packngo.Device
 	rs := acctest.RandString(10)
@@ -448,7 +468,25 @@ resource "packet_device" "test_subnet_29" {
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
   public_ipv4_subnet_size = 29
-}`
+}
+`
+
+func testAccCheckPacketDeviceConfig_facility_list(projSuffix string) string {
+	return fmt.Sprintf(`
+resource "packet_project" "test" {
+  name = "TerraformTestProject-%s"
+}
+
+resource "packet_device" "test"  {
+
+  hostname         = "test-ipxe-script-url"
+  plan             = "baremetal_0"
+  facilities       = ["sjc1", "any"]
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
+}`, projSuffix)
+}
 
 func testAccCheckPacketDeviceConfig_ipxe_script_url(projSuffix, url, pxe string) string {
 	return fmt.Sprintf(`

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -120,7 +120,8 @@ The following arguments are supported:
 * `hostname` - (Required) The device name
 * `project_id` - (Required) The id of the project in which to create the device
 * `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.net/developers/api/#operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
-* `facility` - (Required) The facility in which to create the device. To find the facility code, visit [Facilities API docs](https://www.packet.net/developers/api/#facilities), set your API auth token in the top of the page and see JSON from the API response.
+* `facility` - (Deprecated) The facility in which to create the device.
+* `facilities` - List of facility codes with deployment preferences. Packet API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://www.packet.net/developers/api/#facilities), set your API auth token in the top of the page and see JSON from the API response.
 * `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.net/developers/api/#plans), set your auth token in the top of the page and see JSON from the API response.
 * `billing_cycle` - (Required) monthly or hourly
 * `user_data` (Optional) - A string of the desired User Data for the device.
@@ -145,7 +146,7 @@ The following attributes are exported:
 * `id` - The ID of the device
 * `hostname`- The hostname of the device
 * `project_id`- The ID of the project the device belongs to
-* `facility` - The facility the device is in
+* `facility` - The facility where the device is deployed.
 * `plan` - The hardware config of the device
 * `network` - The device's private and public IP (v4 and v6) network details. When a device is run without any special network configuration, it will have 3 newtworks: private IPv4, public IPv4 and an IPv6 in this order. The fields of the network attribute are:
   * `address` - IPv4 or IPv6 address string


### PR DESCRIPTION
This PR makes it possible to take advantage of Packet API dynamic facility selection. When creating new device, user can specify list of facility codes in `facilities` attribute. Device is then deployed to first facility with free capacity.

Fixes #90 
