### PR TITLE
Project ssh keys

### DIFF
--- a/packet/provider.go
+++ b/packet/provider.go
@@ -27,6 +27,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"packet_device":              resourcePacketDevice(),
 			"packet_ssh_key":             resourcePacketSSHKey(),
+			"packet_project_ssh_key":     resourcePacketProjectSSHKey(),
 			"packet_project":             resourcePacketProject(),
 			"packet_organization":        resourcePacketOrganization(),
 			"packet_volume":              resourcePacketVolume(),

--- a/packet/resource_packet_project_ssh_key.go
+++ b/packet/resource_packet_project_ssh_key.go
@@ -1,0 +1,47 @@
+package packet
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func resourcePacketProjectSSHKey() *schema.Resource {
+	pkeySchema := packetSSHKeyCommonFields()
+	pkeySchema["project_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		ForceNew: true,
+		Required: true,
+	}
+	return &schema.Resource{
+		Create: resourcePacketSSHKeyCreate,
+		Read:   resourcePacketProjectSSHKeyRead,
+		Update: resourcePacketSSHKeyUpdate,
+		Delete: resourcePacketSSHKeyDelete,
+
+		Schema: pkeySchema,
+	}
+}
+
+func resourcePacketProjectSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	projectID := d.Get("project_id").(string)
+	projectKeys, _, err := client.SSHKeys.ProjectList(projectID)
+	if err != nil {
+		return friendlyError(err)
+	}
+	keyFound := false
+	for _, k := range projectKeys {
+		if k.ID == d.Id() {
+			keyFound = true
+			d.Set("name", k.Label)
+			d.Set("public_key", k.Key)
+			d.Set("fingerprint", k.FingerPrint)
+			d.Set("created", k.Created)
+			d.Set("updated", k.Updated)
+		}
+	}
+	if !keyFound {
+		d.SetId("")
+	}
+	return nil
+}

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -1,0 +1,82 @@
+package packet
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/packethost/packngo"
+)
+
+func packetProjectSSHKeyConfig_Basic(publicSshKey string) string {
+	return fmt.Sprintf(`
+resource "packet_project" "test" {
+	name = "test"
+}
+
+resource "packet_project_ssh_key" "test" {
+    name = "test"
+    public_key = "%s"
+    project_id = "${packet_project.test.id}"
+}
+
+resource "packet_device" "test" {
+    hostname            = "test"
+    plan                = "baremetal_0"
+    facility            = "ewr1"
+    operating_system    = "ubuntu_16_04"
+    billing_cycle       = "hourly"
+	project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]
+    project_id          = "${packet_project.test.id}"
+}
+
+`, publicSshKey)
+}
+
+func TestAccPacketProjectSSHKey_Basic(t *testing.T) {
+	var key packngo.SSHKey
+	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+	cfg := packetProjectSSHKeyConfig_Basic(publicKeyMaterial)
+	log.Printf(cfg)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketProjectSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketSSHKeyExists("packet_project_ssh_key.test", &key),
+					resource.TestCheckResourceAttr(
+						"packet_project_ssh_key.test", "public_key", publicKeyMaterial),
+					resource.TestCheckResourceAttrPair(
+						"packet_device.test", "ssh_key_ids.0",
+						"packet_project_ssh_key.test", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPacketProjectSSHKeyDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*packngo.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "packet_project_ssh_key" {
+			continue
+		}
+		if _, _, err := client.SSHKeys.Get(rs.Primary.ID, nil); err == nil {
+			return fmt.Errorf("SSH key still exists")
+		}
+	}
+
+	return nil
+}

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -14,7 +14,7 @@ import (
 func packetProjectSSHKeyConfig_Basic(publicSshKey string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-	name = "test"
+    name = "test"
 }
 
 resource "packet_project_ssh_key" "test" {
@@ -29,7 +29,7 @@ resource "packet_device" "test" {
     facility            = "ewr1"
     operating_system    = "ubuntu_16_04"
     billing_cycle       = "hourly"
-	project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]
+    project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]
     project_id          = "${packet_project.test.id}"
 }
 

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -60,6 +60,10 @@ func TestAccPacketProjectSSHKey_Basic(t *testing.T) {
 						"packet_device.test", "ssh_key_ids.0",
 						"packet_project_ssh_key.test", "id",
 					),
+					resource.TestCheckResourceAttrPair(
+						"packet_project.test", "id",
+						"packet_project_ssh_key.test", "project_id",
+					),
 				),
 			},
 		},

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -138,6 +138,7 @@ The following arguments are supported:
 * `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://help.packet.net/article/61-custom-partitioning-raid) doc.
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
+* `project_ssh_key_ids` - Array if IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.
 
 ## Attributes Reference
 
@@ -173,3 +174,4 @@ The following attributes are exported:
 * `description` - Description string for the device
 * `hardware_reservation_id` - The id of hardware reservation which this device occupies
 * `root_password` - Root password to the server (disabled after 24 hours)
+* `ssh_key_ids` - List of IDs of SSH keys deployed in the device, can be both user and project SSH keys

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -138,7 +138,7 @@ The following arguments are supported:
 * `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://help.packet.net/article/61-custom-partitioning-raid) doc.
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
-* `project_ssh_key_ids` - Array if IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.
+* `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/project_ssh_key.html.markdown
+++ b/website/docs/r/project_ssh_key.html.markdown
@@ -16,7 +16,7 @@ If you supply a list of project SSH keys when creating a new device, only the li
 
 ```hcl
 resource "packet_project" "test" {
-	name = "test"
+    name = "test"
 }
 
 resource "packet_project_ssh_key" "test" {
@@ -31,7 +31,7 @@ resource "packet_device" "test" {
     facility            = "ewr1"
     operating_system    = "ubuntu_16_04"
     billing_cycle       = "hourly"
-	project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]
+    project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]
     project_id          = "${packet_project.test.id}"
 }
 ```

--- a/website/docs/r/project_ssh_key.html.markdown
+++ b/website/docs/r/project_ssh_key.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "packet"
+page_title: "Packet: packet_project_ssh_key"
+sidebar_current: "docs-packet-resource-project-ssh-key"
+description: |-
+  Provides a Packet Project SSH key resource.
+---
+
+# packet_project_ssh_key
+
+Provides a Packet project SSH key resource to manage project-specific SSH keys. On contrary to user SSHK keys, project SSH keys are used to exclusively populate `authorized_keys` in new devices.
+
+If you supply a list of project SSH keys when creating a new device, only the listed keys are used; user SSH keys are ignored.
+
+## Example Usage
+
+```hcl
+resource "packet_project" "test" {
+	name = "test"
+}
+
+resource "packet_project_ssh_key" "test" {
+    name = "test"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDM/unxJeFqxsTJcu6mhqsMHSaVlpu+Jj/P+44zrm6X/MAoHSX3X9oLgujEjjZ74yLfdfe0bJrbL2YgJzNaEkIQQ1VPMHB5EhTKUBGnzlPP0hHTnxsjAm9qDHgUPgvgFDQSAMzdJRJ0Cexo16Ph9VxCoLh3dxiE7s2gaM2FdVg7P8aSxKypsxAhYV3D0AwqzoOyT6WWhBoQ0xZ85XevOTnJCpImSemEGs6nVGEsWcEc1d1YvdxFjAK4SdsKUMkj4Dsy/leKsdi/DEAf356vbMT1UHsXXvy5TlHu/Pa6qF53v32Enz+nhKy7/8W2Yt2yWx8HnQcT2rug9lvCXagJO6oauqRTO77C4QZn13ZLMZgLT66S/tNh2EX0gi6vmIs5dth8uF+K6nxIyKJXbcA4ASg7F1OJrHKFZdTc5v1cPeq6PcbqGgc+8SrPYQmzvQqLoMBuxyos2hUkYOmw3aeWJj9nFa8Wu5WaN89mUeOqSkU4S5cgUzWUOmKey56B/j/s1sVys9rMhZapVs0wL4L9GBBM48N5jAQZnnpo85A8KsZq5ME22bTLqnxsDXqDYZvS7PSI6Dxi7eleOFE/NYYDkrgDLHTQri8ucDMVeVWHgoMY2bPXdn7KKy5jW5jKsf8EPARXg77A4gRYmgKrcwIKqJEUPqyxJBe0CPoGTqgXPRsUiQ== tomk@hp2"
+    project_id = "${packet_project.test.id}"
+}
+
+resource "packet_device" "test" {
+    hostname            = "test"
+    plan                = "baremetal_0"
+    facility            = "ewr1"
+    operating_system    = "ubuntu_16_04"
+    billing_cycle       = "hourly"
+	project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]
+    project_id          = "${packet_project.test.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the SSH key for identification
+* `public_key` - (Required) The public key. If this is a file, it can be read using the file interpolation function
+* `project_id - (Required) The ID of parent project
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique ID of the key
+* `name` - The name of the SSH key
+* `public_key` - The text of the public key
+* `project_id` - The ID of parent project
+* `fingerprint` - The fingerprint of the SSH key
+* `created` - The timestamp for when the SSH key was created
+* `updated` - The timestamp for the last time the SSH key was updated

--- a/website/docs/r/project_ssh_key.html.markdown
+++ b/website/docs/r/project_ssh_key.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # packet_project_ssh_key
 
-Provides a Packet project SSH key resource to manage project-specific SSH keys. On contrary to user SSHK keys, project SSH keys are used to exclusively populate `authorized_keys` in new devices.
+Provides a Packet project SSH key resource to manage project-specific SSH keys. On contrary to user SSH keys, project SSH keys are used to exclusively populate `authorized_keys` in new devices.
 
 If you supply a list of project SSH keys when creating a new device, only the listed keys are used; user SSH keys are ignored.
 

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -41,6 +41,9 @@
             <li<%= sidebar_current("docs-packet-resource-ssh-key") %>>
               <a href="/docs/providers/packet/r/ssh_key.html">packet_ssh_key</a>
             </li>
+            <li<%= sidebar_current("docs-packet-resource-project-ssh-key") %>>
+              <a href="/docs/providers/packet/r/project_ssh_key.html">packet_project_ssh_key</a>
+            </li>
              <li<%= sidebar_current("docs-packet-resource-spot-market-request") %>>
               <a href="/docs/providers/packet/r/spot_market_request.html">packet_spot_market_request</a>
             </li>


### PR DESCRIPTION
This PR adds a resource for project SSH keys, keys which are (not user-, but) project-specific.

If project SSH keys are passed to a new device, no user keys are injected.