### PR TITLE
[doc] Use real plans in the doc

### DIFF
--- a/packet/datasource_packet_precreated_ip_block_test.go
+++ b/packet/datasource_packet_precreated_ip_block_test.go
@@ -44,7 +44,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
   hostname         = "tftest"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "ewr1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -63,7 +63,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
     hostname         = "terraform-test-bgp-sesh"
-    plan             = "baremetal_0"
+    plan             = "t1.small.x86"
     facility         = "ewr1"
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -389,7 +389,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
   hostname         = "test-device-%d"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -408,7 +408,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test-device-%d"
   description      = "test-desc-%d"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -427,7 +427,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test-device-%d"
   description      = "test-desc-%d"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -447,7 +447,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
   hostname         = "test-device"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -462,7 +462,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test_subnet_29" {
   hostname         = "test-subnet-29"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -480,7 +480,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test"  {
 
   hostname         = "test-ipxe-script-url"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facilities       = ["sjc1", "any"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
@@ -497,7 +497,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test_ipxe_script_url"  {
 
   hostname         = "test-ipxe-script-url"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "custom_ipxe"
   user_data        = "#!/bin/sh\ntouch /tmp/test"
@@ -515,7 +515,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test_ipxe_conflict" {
   hostname         = "test-ipxe-conflict"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "custom_ipxe"
   user_data        = "#!ipxe\nset conflict ipxe_script_url"
@@ -532,7 +532,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test_ipxe_missing" {
   hostname         = "test-ipxe-missing"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"

--- a/packet/resource_packet_ip_attachment_test.go
+++ b/packet/resource_packet_ip_attachment_test.go
@@ -61,7 +61,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
   hostname         = "test"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "ewr1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -88,6 +88,6 @@ var testAccCheckPacketSpotMarketRequestConfig_basic = `
 		  "hostname"         = "testspot"
 		  "billing_cycle"    = "hourly"
 		  "operating_system" = "coreos_stable"
-		  "plan"             = "baremetal_0"
+		  "plan"             = "t1.small.x86"
 		}
 	  }`

--- a/packet/resource_packet_volume_attachment_test.go
+++ b/packet/resource_packet_volume_attachment_test.go
@@ -61,7 +61,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
     hostname         = "terraform-test-device-va"
-    plan             = "baremetal_0"
+    plan             = "t1.small.x86"
     facility         = "ewr1"
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"

--- a/website/docs/d/operating_system.html.markdown
+++ b/website/docs/d/operating_system.html.markdown
@@ -17,12 +17,12 @@ data "packet_operating_system" "example" {
   name             = "Container Linux"
   distro           = "coreos"
   version          = "alpha"
-  provisionable_on = "baremetal_1"
+  provisionable_on = "c1.small.x86"
 }
 
 resource "packet_device" "server" {
   hostname         = "tf.coreos2"
-  plan             = "baremetal_1"
+  plan             = "c1.small.x86"
   facility         = "ewr1"
   operating_system = "${data.packet_operating_system.example.id}"
   billing_cycle    = "hourly"

--- a/website/docs/d/precreated_ip_block.html.markdown
+++ b/website/docs/d/precreated_ip_block.html.markdown
@@ -25,7 +25,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "web1" {
   hostname         = "tftest"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "ewr1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/website/docs/d/spot_market_price.html.markdown
+++ b/website/docs/d/spot_market_price.html.markdown
@@ -15,7 +15,7 @@ Use this data source to get Packet Spot Market Price.
 ```hcl
 data "packet_spot_market_price" "example" {
   facility = "ewr1"
-  plan     = "baremetal_1"
+  plan     = "c1.small.x86"
 }
 ```
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -30,7 +30,7 @@ resource "packet_project" "cool_project" {
 # Create a device and add it to tf_project_1
 resource "packet_device" "web1" {
   hostname         = "tf.coreos2"
-  plan             = "baremetal_1"
+  plan             = "c1.small.x86"
   facility         = "ewr1"
   operating_system = "coreos_stable"
   billing_cycle    = "hourly"

--- a/website/docs/r/bgp_session.html.markdown
+++ b/website/docs/r/bgp_session.html.markdown
@@ -47,7 +47,7 @@ resource "packet_reserved_ip_block" "addr" {
 
 resource "packet_device" "test" {
     hostname         = "terraform-test-bgp-sesh"
-    plan             = "baremetal_0"
+    plan             = "t1.small.x86"
     facility         = "ewr1"
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -22,7 +22,7 @@ modify, and delete devices.
 # Create a device and add it to cool_project
 resource "packet_device" "web1" {
   hostname         = "tf.coreos2"
-  plan             = "baremetal_1"
+  plan             = "t1.small.x86"
   facility         = "ewr1"
   operating_system = "coreos_stable"
   billing_cycle    = "hourly"
@@ -34,7 +34,7 @@ resource "packet_device" "web1" {
 # Same as above, but boot via iPXE initially, using the Ignition Provider for provisioning
 resource "packet_device" "pxe1" {
   hostname         = "tf.coreos2-pxe"
-  plan             = "baremetal_1"
+  plan             = "t1.small.x86"
   facility         = "ewr1"
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"
@@ -49,7 +49,7 @@ resource "packet_device" "pxe1" {
 # Deploy device on next-available reserved hardware and do custom partitioning.
 resource "packet_device" "web1" {
   hostname         = "tftest"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/website/docs/r/spot_market_request.html.markdown
+++ b/website/docs/r/spot_market_request.html.markdown
@@ -26,7 +26,7 @@ resource "packet_spot_market_request" "req" {
     "hostname"         = "testspot"
     "billing_cycle"    = "hourly"
     "operating_system" = "coreos_stable"
-    "plan"             = "baremetal_0"
+    "plan"             = "t1.small.x86"
   }
 }
 ```

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -25,7 +25,7 @@ resource "packet_ssh_key" "key1" {
 # key, in order to make sure the key is created before the device.
 resource "packet_device" "test" {
   hostname         = "test-device"
-  plan             = "baremetal_0"
+  plan             = "t1.small.x86"
   facility         = "sjc1"
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -23,7 +23,7 @@ Once attached by Terraform, they must then be mounted using the `packet_block_at
 
   resource "packet_device" "test_device_va" {
       hostname         = "terraform-test-device-va"
-      plan             = "baremetal_0"
+      plan             = "t1.small.x86"
       facility         = "ewr1"
       operating_system = "ubuntu_16_04"
       billing_cycle    = "hourly"


### PR DESCRIPTION
I think that giving real example will more, AFAIK `plan = "baremetal_1"` is not something that would work.