### PR TITLE
create useful error string when none generated from packngo

### DIFF
--- a/packet/errors.go
+++ b/packet/errors.go
@@ -2,6 +2,7 @@ package packet
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/packethost/packngo"
@@ -9,9 +10,17 @@ import (
 
 func friendlyError(err error) error {
 	if e, ok := err.(*packngo.ErrorResponse); ok {
+		errors := Errors(e.Errors)
+		/*
+		 ** if packngo gives us blank error strings, populate them with something useful
+                 ** this is useful so the user gets some sort of indication of a failure rather than a blank message
+		 */
+		if 0 == len(errors) {
+			errors = Errors{strconv.Itoa(e.Response.StatusCode) + " " + http.StatusText(e.Response.StatusCode)}
+		}
 		return &ErrorResponse{
 			StatusCode: e.Response.StatusCode,
-			Errors:     Errors(e.Errors),
+			Errors:     errors,
 		}
 	}
 	return err

--- a/packet/errors.go
+++ b/packet/errors.go
@@ -2,7 +2,6 @@ package packet
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/packethost/packngo"
@@ -11,12 +10,10 @@ import (
 func friendlyError(err error) error {
 	if e, ok := err.(*packngo.ErrorResponse); ok {
 		errors := Errors(e.Errors)
-		/*
-		 ** if packngo gives us blank error strings, populate them with something useful
-                 ** this is useful so the user gets some sort of indication of a failure rather than a blank message
-		 */
+		// if packngo gives us blank error strings, populate them with something useful
+		// this is useful so the user gets some sort of indication of a failure rather than a blank message
 		if 0 == len(errors) {
-			errors = Errors{strconv.Itoa(e.Response.StatusCode) + " " + http.StatusText(e.Response.StatusCode)}
+			errors = Errors{e.SingleError}
 		}
 		return &ErrorResponse{
 			StatusCode: e.Response.StatusCode,

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -126,8 +126,8 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 	if reservedBlock.AddressFamily == 4 {
 		d.Set("quantity", ipv4CIDRToQuantity[reservedBlock.CIDR])
 	} else {
-		// In Packet, reserved IPv6 block is allocated when device is run in a proejct.
-		// It's always /56, and it can't be crated with Terraform, only imported.
+		// In Packet, a reserved IPv6 block is allocated when a device is run in a project.
+		// It's always /56, and it can't be created with Terraform, only imported.
 		// The longest assignable prefix is /64, making it max 256 subnets per block.
 		// The following logic will hold as long as /64 is the smallest assignable subnet size.
 		bits := 64 - reservedBlock.CIDR


### PR DESCRIPTION
in specific, when an invalid token is used, a 401 will be generated without an error message
this now passes back up the 401 and an error string to the user rather than a blank message

previously, the user would be presented with no error string and would have to turn on TF_LOG=DEBUG
to figure out what happened