### PR TITLE
Handle resources that have been removed outside of TF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 - [#104](https://github.com/terraform-providers/terraform-provider-packet/pull/104) Fix empty error messages on invalid credentials
+- [#111](https://github.com/terraform-providers/terraform-provider-packet/pull/111) Fix handling of resources deleted out of Terraform
 
 ## 1.3.2 (February 06, 2019)
 

--- a/packet/resource_packet_bgp_session.go
+++ b/packet/resource_packet_bgp_session.go
@@ -58,6 +58,7 @@ func resourcePacketBGPSessionRead(d *schema.ResourceData, meta interface{}) erro
 	bgpSession, _, err := client.BGPSessions.Get(d.Id(),
 		&packngo.GetOptions{Includes: []string{"device"}})
 	if err != nil {
+		err = friendlyError(err)
 		if isNotFound(err) {
 			d.SetId("")
 			return nil

--- a/packet/resource_packet_ip_attachment.go
+++ b/packet/resource_packet_ip_attachment.go
@@ -94,15 +94,7 @@ func resourcePacketIPAttachmentDelete(d *schema.ResourceData, meta interface{}) 
 
 	_, err := client.DeviceIPs.Unassign(d.Id())
 	if err != nil {
-		err = friendlyError(err)
-
-		// If the IP attachment was already destroyed, mark as succesfully gone.
-		if isNotFound(err) {
-			log.Printf("[DEBUG] The IP attachment %q not found or has been deleted", d.Id())
-			d.SetId("")
-			return nil
-		}
-		return err
+		return friendlyError(err)
 	}
 
 	d.SetId("")

--- a/packet/resource_packet_project_ssh_key.go
+++ b/packet/resource_packet_project_ssh_key.go
@@ -27,8 +27,15 @@ func resourcePacketProjectSSHKeyRead(d *schema.ResourceData, meta interface{}) e
 	projectID := d.Get("project_id").(string)
 	projectKeys, _, err := client.SSHKeys.ProjectList(projectID)
 	if err != nil {
-		return friendlyError(err)
+		err = friendlyError(err)
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+
+		return err
 	}
+
 	keyFound := false
 	for _, k := range projectKeys {
 		if k.ID == d.Id() {

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -203,6 +203,7 @@ func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{})
 
 	reservedBlock, _, err := client.ProjectIPs.Get(id, nil)
 	if err != nil {
+		err = friendlyError(err)
 		if isNotFound(err) {
 			d.SetId("")
 			return nil

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -217,6 +217,7 @@ func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{
 
 	smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
 	if err != nil {
+		err = friendlyError(err)
 		if isNotFound(err) {
 			d.SetId("")
 			return nil

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -217,6 +217,10 @@ func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{
 
 	smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
 	if err != nil {
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/packet/resource_packet_vlan.go
+++ b/packet/resource_packet_vlan.go
@@ -59,11 +59,12 @@ func resourcePacketVlanRead(d *schema.ResourceData, meta interface{}) error {
 	vlan, _, err := c.ProjectVirtualNetworks.Get(d.Id(),
 		&packngo.GetOptions{Includes: []string{"assigned_to"}})
 	if err != nil {
+		err = friendlyError(err)
 		if isNotFound(err) {
 			d.SetId("")
 			return nil
 		}
-		return friendlyError(err)
+		return err
 
 	}
 	d.Set("description", vlan.Description)

--- a/packet/resource_packet_volume_attachment.go
+++ b/packet/resource_packet_volume_attachment.go
@@ -61,6 +61,10 @@ func resourcePacketVolumeAttachmentRead(d *schema.ResourceData, meta interface{}
 	client := meta.(*packngo.Client)
 	va, _, err := client.VolumeAttachments.Get(d.Id(), nil)
 	if err != nil {
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.Set("device_id", filepath.Base(va.Device.Href))

--- a/packet/resource_packet_volume_attachment.go
+++ b/packet/resource_packet_volume_attachment.go
@@ -61,6 +61,7 @@ func resourcePacketVolumeAttachmentRead(d *schema.ResourceData, meta interface{}
 	client := meta.(*packngo.Client)
 	va, _, err := client.VolumeAttachments.Get(d.Id(), nil)
 	if err != nil {
+		err = friendlyError(err)
 		if isNotFound(err) {
 			d.SetId("")
 			return nil


### PR DESCRIPTION
aligning error handling to be the same as the rest of the code base
properly handle when a resource has been removed outside of Terraform

resolves https://github.com/terraform-providers/terraform-provider-packet/issues/108