### PR TITLE
Devices datasource

### DIFF
--- a/packet/datasource_packet_devices.go
+++ b/packet/datasource_packet_devices.go
@@ -1,0 +1,161 @@
+package packet
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourcePacketDevices() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePacketDevicesRead,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:          schema.TypeString,
+				Required:      true,
+				ConflictsWith: []string{"spot_market_request_id"},
+			},
+			"spot_market_request_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"project_id"},
+			},
+			"tags": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"facilities": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"plans": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"operating_systems": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"public_ipv4s": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"private_ipv4s": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"public_ipv6s": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func getComputedListsFromDeviceList(devices []packngo.Device) (ids, pub4, pri4, pub6 []string) {
+	for _, d := range devices {
+		ids = append(ids, d.ID)
+		pu4, pr4, pu6 := getPub4Pri4Pub6(d.Network)
+		pub4 = append(pub4, pu4)
+		pri4 = append(pri4, pr4)
+		pub6 = append(pub6, pu6)
+	}
+}
+
+func getPub4Pri4Pub6(ns []*packngo.IPAddressAssignment) (pub4, pri4, pub6 string) {
+	for _, ip := range ns {
+		if ip.Management {
+			if ip.AddressFamily == 4 {
+				if ip.Public {
+					pub4 = ip.Address
+				} else {
+					pri4 = ip.Address
+				}
+			} else {
+				pub6 = ip.Address
+			}
+		}
+	}
+
+}
+
+type deviceFilter = func([]string, packngo.Device) bool
+
+func tagFilter(f []string, d packngo.Device) bool {
+	return stringSlicesIntersect(f, d.Tags)
+}
+
+func facilityFilter(f []string, d packngo.Device) bool {
+	return contains(f, d.Facility.Code)
+}
+
+func planFilter(f []string, d packngo.Device) bool {
+	return contains(f, d.Plan.Slug) || contains(f, d.Plan.Name)
+}
+
+func osFilter(f []string, d packngo.Device) bool {
+	return contains(f, d.OperatingSystem.Slug)
+}
+
+func nameFilter(f []string, d packngo.Device) bool {
+	return contains(f, d.Hostname)
+}
+
+func dataSourcePacketDevicesRead(d *schema.ResourceData, meta interface{}) error {
+	var ids, pub4, pri4, pub6 []string
+	var ds []packngo.Device
+	client := meta.(*packngo.Client)
+	spotOK, smrIdRaw := d.GetOk("spot_market_request_id")
+
+	if spotOK {
+		opts := packngo.GetOptions{Includes: []string{"devices"}}
+		smr, _, err := client.SpotMarketRequests.Get(smrIdRaw.(string), &opts)
+		if err != nil {
+			return friendlyError(err)
+		}
+		ds = smr.Devices
+	} else {
+		pid := d.Get("project_id").(string)
+		ds, _, err := client.Devices.List(pid, nil)
+		if err != nil {
+			return friendlyError(err)
+		}
+	}
+	// tags, facilities, plans, operating_systems
+	fields := []string{"tags", "names", "facilities", "plans", "operating_systems"}
+	filters := []deviceFilter{tagFilter, nameFilter, facilityFilter, planFilter, osFilter}
+
+	for i, field := range fields {
+		n := d.Get(field + ".#").(int)
+		if n > 0 {
+			newDs := []packngo.Devices{}
+			values := convertStringArr(d.Get(field).([]interface{}))
+			for _, d := range ds {
+				if filters[i](values, d) {
+					newDs = append(newDs, d)
+				}
+			}
+			ds = newDs
+		}
+	}
+
+	ids, pub4, pri4, pub6 = getComputedListsFromDeviceList(ds)
+	d.Set("ids", ids)
+	d.Set("public_ipv4s", pub4)
+	d.Set("private_ipv4s", pri4)
+	d.Set("public_ipv6s", pub6)
+
+	return nil
+
+}

--- a/packet/datasource_packet_devices_test.go
+++ b/packet/datasource_packet_devices_test.go
@@ -1,0 +1,33 @@
+package packet
+
+func testAccDatasourceDevicesConfig(projSuffix string) string {
+	return fmt.Sprintf(`
+resource "packet_project" "test" {
+    name = "TerraformTestProject-%s"
+}
+
+resource "packet_device" "d1" {
+  hostname         = "d1"
+  plan             = "t1.small.x86"
+  facility         = "sjc1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
+}
+
+resource "packet_device" "d2" {
+  hostname         = "d2"
+  plan             = "t1.small.x86"
+  facility         = "sjc1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
+}
+
+data "packet_devices "testdevs" {
+  names = ["d1", "d2"]
+  depends_on = ["packet_device.d1", "packet_device.d2"]
+}
+`
+
+

--- a/packet/datasource_packet_devices_test.go
+++ b/packet/datasource_packet_devices_test.go
@@ -1,5 +1,13 @@
 package packet
 
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
 func testAccDatasourceDevicesConfig(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
@@ -24,10 +32,35 @@ resource "packet_device" "d2" {
   project_id       = "${packet_project.test.id}"
 }
 
-data "packet_devices "testdevs" {
-  names = ["d1", "d2"]
-  depends_on = ["packet_device.d1", "packet_device.d2"]
+resource "packet_device" "d3" {
+  hostname         = "d3"
+  plan             = "t1.small.x86"
+  facility         = "sjc1"
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
 }
-`
 
+data "packet_devices" "testdevs" {
+  names = ["d1", "d2"]
+  depends_on = ["packet_device.d1", "packet_device.d2", "packet_device.d3]
+}
 
+`, projSuffix)
+}
+
+func TestAccDataSourcePacketDevices_Basic(t *testing.T) {
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{Config: testAccDataSourceDevicesConfig(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.packet_devices", "id", "coreos_alpha"),
+				),
+			},
+		},
+	})
+}

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -22,6 +22,7 @@ func Provider() terraform.ResourceProvider {
 			"packet_precreated_ip_block": dataSourcePacketPreCreatedIPBlock(),
 			"packet_operating_system":    dataSourceOperatingSystem(),
 			"packet_spot_market_price":   dataSourceSpotMarketPrice(),
+			"packet_devices":             dataSourcePacketDevices(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/packet/utils.go
+++ b/packet/utils.go
@@ -19,3 +19,14 @@ func convertStringArr(ifaceArr []interface{}) []string {
 	}
 	return arr
 }
+
+func stringSlicesIntersect(a, b []string) bool {
+	for _, i := range a {
+		for _, j := range b {
+			if a == b {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/packet/utils.go
+++ b/packet/utils.go
@@ -23,7 +23,7 @@ func convertStringArr(ifaceArr []interface{}) []string {
 func stringSlicesIntersect(a, b []string) bool {
 	for _, i := range a {
 		for _, j := range b {
-			if a == b {
+			if i == j {
 				return true
 			}
 		}


### PR DESCRIPTION
This adds a new `packet_devices` datasource which can be used to retrieve info about existing devices in a project or from a spot market request.

It resolves #107