### PR TITLE
Fix doc links to aim to support.packet.com

### DIFF
--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -119,23 +119,23 @@ The following arguments are supported:
 
 * `hostname` - (Required) The device name
 * `project_id` - (Required) The id of the project in which to create the device
-* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.net/developers/api/#operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
+* `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.com/developers/api/#operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
 * `facility` - (Deprecated) The facility in which to create the device.
-* `facilities` - List of facility codes with deployment preferences. Packet API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://www.packet.net/developers/api/#facilities), set your API auth token in the top of the page and see JSON from the API response.
-* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.net/developers/api/#plans), set your auth token in the top of the page and see JSON from the API response.
+* `facilities` - List of facility codes with deployment preferences. Packet API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://www.packet.com/developers/api/#facilities), set your API auth token in the top of the page and see JSON from the API response.
+* `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.com/developers/api/#plans), set your auth token in the top of the page and see JSON from the API response.
 * `billing_cycle` - (Required) monthly or hourly
 * `user_data` (Optional) - A string of the desired User Data for the device.
 * `public_ipv4_subnet_size` (Optional) - Size of allocated subnet, more
   information is in the
-  [Custom Subnet Size](https://help.packet.net/article/55-custom-subnet-size) doc.
+  [Custom Subnet Size](https://support.packet.com/kb/articles/custom-subnet-size) doc.
 * `ipxe_script_url` (Optional) - URL pointing to a hosted iPXE script. More
   information is in the
-  [Custom iPXE](https://help.packet.net/article/26-custom-ipxe)
+  [Custom iPXE](https://support.packet.com/kb/articles/custom-ipxe)
   doc.
 * `always_pxe` (Optional) - If true, a device with OS `custom_ipxe` will
   continue to boot via iPXE on reboots.
 * `hardware_reservation_id` (Optional) - The id of hardware reservation where you want this device deployed, or `next-available` if you want to pick your next available reservation automatically.
-* `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://help.packet.net/article/61-custom-partitioning-raid) doc.
+* `storage` (Optional) - JSON for custom partitioning. Only usable on reserved hardware. More information in in the [Custom Partitioning and RAID](https://support.packet.com/kb/articles/custom-partitioning-raid) doc.
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
 * `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.

--- a/website/docs/r/ip_attachment.html.markdown
+++ b/website/docs/r/ip_attachment.html.markdown
@@ -15,7 +15,7 @@ one of your reserved blocks in the same project and facility as the target devic
 
 For example, you have reserved IPv4 address block 147.229.10.152/30, you can choose to assign either the whole
 block as one subnet to a device; or 2 subnets with CIDRs 147.229.10.152/31' and 147.229.10.154/31; or 4 subnets
-with mask prefix length 32. More about the elastic IP subnets is [here](https://help.packet.net/article/54-elastic-ips).
+with mask prefix length 32. More about the elastic IP subnets is [here](https://support.packet.com/kb/articles/elastic-ips).
 
 Device and reserved block must be in the same facility.
 

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -38,7 +38,7 @@ resource "packet_project" "tf_project_1" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the project on Packet.net
+* `name` - (Required) The name of the project
 * `organization_id` - The UUID of organization under which you want to create the project. If you leave it out, the project will be create under your the default organization of your account.
 * `payment_method_id` - The UUID of payment method for this project. The payment method and the project need to belong to the same organization (passed with `organization_id`, or default).
 * `bgp_config` - Optional BGP settings. Refer to [Packet guide for BGP](https://support.packet.com/kb/articles/bgp).

--- a/website/docs/r/spot_market_request.html.markdown
+++ b/website/docs/r/spot_market_request.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # packet\_spot\_market\_request
 
 Provides a Packet Spot Market Request resource to allow you to
-manage spot market requests on your account. https://help.packet.net/en-us/article/20-spot-market 
+manage spot market requests on your account. https://support.packet.com/kb/articles/spot-market 
 
 ## Example Usage
 

--- a/website/docs/r/vlan.html.markdown
+++ b/website/docs/r/vlan.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # packet_vlan
 
-Provides a resource to allow users to manage Virtual Networks in their projects. VLANs are used in [Layer 2 networking setup](https://packet.kayako.com/article/57-layer-2-overview).
+Provides a resource to allow users to manage Virtual Networks in their projects. VLANs are used in [Layer 2 networking setup](https://support.packet.com/kb/articles/layer-2-overview).
 
 ## Example Usage
 


### PR DESCRIPTION
This is a docs fix, so that resouce docs point to proper articles in support.packet.com