### PR TITLE
Reservation deprovision guard on device removal

### DIFF
--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -140,6 +140,7 @@ The following arguments are supported:
 * `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.
 * `network_type` (Optional) - Network type of device, used for [Layer 2 networking](https://support.packet.com/kb/articles/layer-2-overview). Allowed values are `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`. If you keep it empty, Terraform will not handle the network type of the device.
 * `ip_address_types` (Optional) - A set containing one or more of [`private_ipv4`, `public_ipv4`, `public_ipv6`]. It specifies which IP address types a new device should obtain. If omitted, a created device will obtain all 3 addresses. If you only want private IPv4 address for the new device, pass [`private_ipv4`].
+* `wait_for_reservation_deprovision` (Optional) - Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds an attribute to the packet_device resource - `wait_for_reservation_deprovision` which, when set, causes Terraform wait until hw reservation, where the removed device was deployed, is again provisionable. Fixes #124 