### PR TITLE
docs/provider: Sort resource list and include packet_ prefix for data sources in sidebar

### DIFF
--- a/website/packet.erb
+++ b/website/packet.erb
@@ -14,13 +14,13 @@
          <a href="#">Data Sources</a>
          <ul class="nav nav-visible">
            <li<%= sidebar_current("docs-packet-datasource-precreated-ip-block") %>>
-             <a href="/docs/providers/packet/d/precreated_ip_block.html">precreated_ip_block</a>
+             <a href="/docs/providers/packet/d/precreated_ip_block.html">packet_precreated_ip_block</a>
            </li>
            <li<%= sidebar_current("docs-packet-datasource-operating-system") %>>
-             <a href="/docs/providers/packet/d/operating_system.html">operating_system</a>
+             <a href="/docs/providers/packet/d/operating_system.html">packet_operating_system</a>
            </li>
             <li<%= sidebar_current("docs-packet-datasource-spot-market-price") %>>
-             <a href="/docs/providers/packet/d/spot_market_price.html">spot_market_price</a>
+             <a href="/docs/providers/packet/d/spot_market_price.html">packet_spot_market_price</a>
            </li>
          </ul>
        </li>
@@ -29,46 +29,44 @@
         <li<%= sidebar_current("docs-packet-resource") %>>
           <a href="#">Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-packet-resource-bgp-session") %>>
+              <a href="/docs/providers/packet/r/bgp_session.html">packet_bgp_session</a>
+            </li>
             <li<%= sidebar_current("docs-packet-resource-device") %>>
               <a href="/docs/providers/packet/r/device.html">packet_device</a>
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-project") %>>
-              <a href="/docs/providers/packet/r/project.html">packet_project</a>
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-organization") %>>
-              <a href="/docs/providers/packet/r/organization.html">packet_organization</a>
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-ssh-key") %>>
-              <a href="/docs/providers/packet/r/ssh_key.html">packet_ssh_key</a>
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-project-ssh-key") %>>
-              <a href="/docs/providers/packet/r/project_ssh_key.html">packet_project_ssh_key</a>
-            </li>
-             <li<%= sidebar_current("docs-packet-resource-spot-market-request") %>>
-              <a href="/docs/providers/packet/r/spot_market_request.html">packet_spot_market_request</a>
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-volume") %>>
-              <a href="/docs/providers/packet/r/volume.html">packet_volume</a>
-          </li>
-          <li<%= sidebar_current("docs-packet-resource-volume-attachment") %>>
-              <a href="/docs/providers/packet/r/volume_attachment.html">packet_volume_attachment</a>
-            </li>
-
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-reserved-ip-block") %>>
-              <a href="/docs/providers/packet/r/reserved_ip_block.html">packet_reserved_ip_block</a>
             </li>
             <li<%= sidebar_current("docs-packet-resource-ip-attachment") %>>
               <a href="/docs/providers/packet/r/ip_attachment.html">packet_ip_attachment</a>
             </li>
-            <li<%= sidebar_current("docs-packet-resource-vlan") %>>
-              <a href="/docs/providers/packet/r/vlan.html">packet_vlan</a>
-            </li>
-            <li<%= sidebar_current("docs-packet-resource-bgp-session") %>>
-              <a href="/docs/providers/packet/r/bgp_session.html">packet_bgp_session</a>
+            <li<%= sidebar_current("docs-packet-resource-organization") %>>
+              <a href="/docs/providers/packet/r/organization.html">packet_organization</a>
             </li>
             <li<%= sidebar_current("docs-packet-resource-port-vlan-attachment") %>>
               <a href="/docs/providers/packet/r/port_vlan_attachment.html">packet_port_vlan_attachment</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-project") %>>
+              <a href="/docs/providers/packet/r/project.html">packet_project</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-project-ssh-key") %>>
+              <a href="/docs/providers/packet/r/project_ssh_key.html">packet_project_ssh_key</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-reserved-ip-block") %>>
+              <a href="/docs/providers/packet/r/reserved_ip_block.html">packet_reserved_ip_block</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-ssh-key") %>>
+              <a href="/docs/providers/packet/r/ssh_key.html">packet_ssh_key</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-spot-market-request") %>>
+              <a href="/docs/providers/packet/r/spot_market_request.html">packet_spot_market_request</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-vlan") %>>
+              <a href="/docs/providers/packet/r/vlan.html">packet_vlan</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-volume") %>>
+              <a href="/docs/providers/packet/r/volume.html">packet_volume</a>
+            </li>
+            <li<%= sidebar_current("docs-packet-resource-volume-attachment") %>>
+              <a href="/docs/providers/packet/r/volume_attachment.html">packet_volume_attachment</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Previously:

![Screen Shot 2019-03-21 at 10 06 31 AM](https://user-images.githubusercontent.com/189114/54757653-0bc8ef80-4bc1-11e9-958f-8af8b2277aa0.png)

Now:

![Screen Shot 2019-03-21 at 10 02 51 AM](https://user-images.githubusercontent.com/189114/54757619-f784f280-4bc0-11e9-88f0-4cdc2ec30913.png)
