### PR TITLE
add default_route flag to bgp session

### DIFF
--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -24,6 +24,8 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"packet_device.test", "id",
 						"packet_bgp_session.test", "device_id"),
+					resource.TestCheckResourceAttr(
+						"packet_bgp_session.test", "default_route", "true"),
 				),
 			},
 			resource.TestStep{
@@ -73,5 +75,6 @@ resource "packet_device" "test" {
 resource "packet_bgp_session" "test" {
 	device_id = "${packet_device.test.id}"
 	address_family = "ipv4"
+	default_route = true
 }`, name)
 }

--- a/website/docs/r/bgp_session.html.markdown
+++ b/website/docs/r/bgp_session.html.markdown
@@ -158,7 +158,8 @@ resource "null_resource" "configure_bird" {
 The following arguments are supported:
 
 * `device_id` - (Required) ID of device 
-* `address_family` - `ipv4` or `ipv6`
+* `address_family` - (Required) `ipv4` or `ipv6`
+* `default_route` - (Optional) Boolean flag to set the default route policy. False by default.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds a bool flag to packet_bgp_session to set the default route policy.

@patrickdevivo Please review. Is False by default OK?