### PR TITLE
fix packet_port_vlan_attachment resource for layer2-bonded usecase

### DIFF
--- a/packet/resource_packet_port_vlan_attachment.go
+++ b/packet/resource_packet_port_vlan_attachment.go
@@ -101,13 +101,6 @@ func resourcePacketPortVlanAttachmentCreate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("VLAN with VNID %d doesn't exist in facilty %s", vlanVNID, facility)
 	}
 
-	if port.Data.Bonded {
-		_, _, err := client.DevicePorts.Disbond(&packngo.DisbondRequest{PortID: port.ID, BulkDisable: false})
-		if err != nil {
-			return friendlyError(err)
-		}
-	}
-
 	par := &packngo.PortAssignRequest{PortID: port.ID, VirtualNetworkID: vlanID}
 
 	_, _, err = client.DevicePorts.Assign(par)


### PR DESCRIPTION
This PR fixes the usecase for l2-bonded where vlans are added to bonded port (bond0).

Initially I assumed that a port must be removed from bond before VLAN is added to it, but it's not the case for l2-bonded, so I fix it with this PR.