### PR TITLE
disregard network_type of packet_device unless the user specifies it

### DIFF
--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
 * `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.
-* `network_type` - Network type of device, used for [Layer 2 networking](https://support.packet.com/kb/articles/layer-2-overview). Allowed values are `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`. Default is `layer3`. 
+* `network_type` (Optional) - Network type of device, used for [Layer 2 networking](https://support.packet.com/kb/articles/layer-2-overview). Allowed values are `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`. If you keep it empty, Terraform will not handle the network type of the device.
 
 ## Attributes Reference
 
@@ -161,7 +161,6 @@ The following attributes are exported:
   * `gateway` - address of router
   * `public` - whether the address is routable from the Internet
   * `family` - IP version - "4" or "6"
- 
 * `access_public_ipv6` - The ipv6 maintenance IP assigned to the device
 * `access_public_ipv4` - The ipv4 maintenance IP assigned to the device
 * `access_private_ipv4` - The ipv4 private IP assigned to the device


### PR DESCRIPTION
This PR makes the packet_device resource disregard the network type of the deivce unless the user specifies it. It will make provisioning faster, and make the packet_device independent of L2 bugs such as https://github.com/packethost/packngo/issues/141

fixes #138 