### PR TITLE
Remove deprecated 'facility' attr, fix device import

### DIFF
--- a/packet/datasource_packet_precreated_ip_block_test.go
+++ b/packet/datasource_packet_precreated_ip_block_test.go
@@ -45,7 +45,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "tftest"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -66,7 +66,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
     hostname         = "terraform-test-bgp-sesh"
     plan             = "t1.small.x86"
-    facility         = "ewr1"
+    facilities       = ["ewr1"]
     operating_system = "ubuntu_16_04"
     billing_cycle    = "hourly"
     project_id       = "${packet_project.test.id}"

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -65,7 +65,7 @@ func resourcePacketDevice() *schema.Resource {
 
 			"facilities": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -435,9 +435,7 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("hostname", device.Hostname)
 	d.Set("plan", device.Plan.Slug)
-	d.Set("facilities", []string{device.Facility.Code})
 	d.Set("deployed_facility", device.Facility.Code)
-
 	d.Set("operating_system", device.OS.Slug)
 	d.Set("state", device.State)
 	d.Set("billing_cycle", device.BillingCycle)

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -52,28 +52,22 @@ func resourcePacketDevice() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"deployed_facility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"facility": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ValidateFunc:  validateFacilityForDevice,
-				Deprecated:    "Use the 'facilities' array instead.",
-				ConflictsWith: []string{"facilities"},
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// ignore set of empty facility "" => "xxx1"
-					if new == "" {
-						return true
-					}
-					return false
-				},
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use the 'facilities' array instead, i.e. change facility = \"ewr1\" to facilities = [\"ewr1\"].",
 			},
 
 			"facilities": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				ForceNew:      true,
-				Elem:          &schema.Schema{Type: schema.TypeString},
-				ConflictsWith: []string{"facility"},
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
 			"plan": {
@@ -441,7 +435,9 @@ func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("hostname", device.Hostname)
 	d.Set("plan", device.Plan.Slug)
-	d.Set("facility", device.Facility.Code)
+	d.Set("facilities", []string{device.Facility.Code})
+	d.Set("deployed_facility", device.Facility.Code)
+
 	d.Set("operating_system", device.OS.Slug)
 	d.Set("state", device.State)
 	d.Set("billing_cycle", device.BillingCycle)

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -76,6 +76,9 @@ func resourcePacketDevice() *schema.Resource {
 					if contains(fs, df) {
 						return true
 					}
+					if contains(fs, "any") && (len(df) != 0) {
+						return true
+					}
 					return false
 				},
 			},

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -84,6 +84,8 @@ func TestAccPacketDevice_Basic(t *testing.T) {
 						r, "always_pxe", "false"),
 					resource.TestCheckResourceAttrSet(
 						r, "root_password"),
+					resource.TestCheckResourceAttrPair(
+						r, "deployed_facility", r, "facilities.0"),
 				),
 			},
 		},
@@ -231,45 +233,6 @@ func TestAccPacketDevice_L2(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"packet_device.test", "network_type", "layer2-bonded"),
 				),
-			},
-		},
-	})
-}
-
-func testAccCheckPacketDeviceConfig_AnyFacility(projSuffix string) string {
-	return fmt.Sprintf(`
-resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
-}
-
-resource "packet_device" "test" {
-  hostname         = "test"
-  plan             = "t1.small.x86"
-  facility         = "any"
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${packet_project.test.id}"
-}
-`, projSuffix)
-}
-
-var matchErrAnyFacility = regexp.MustCompile(`.*Cannot use facility: "any".*`)
-
-func TestAccPacketDevice_AnyFacility(t *testing.T) {
-	var device packngo.Device
-	rs := acctest.RandString(10)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPacketDeviceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckPacketDeviceConfig_AnyFacility(rs),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPacketDeviceExists("packet_device.test", &device),
-				),
-				ExpectError: matchErrAnyFacility,
 			},
 		},
 	})
@@ -489,7 +452,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test-device-%d"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -508,7 +471,7 @@ resource "packet_device" "test" {
   hostname         = "test-device-%d"
   description      = "test-desc-%d"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -527,7 +490,7 @@ resource "packet_device" "test" {
   hostname         = "test-device-%d"
   description      = "test-desc-%d"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -547,7 +510,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test-device"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -562,7 +525,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test_subnet_29" {
   hostname         = "test-subnet-29"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -597,7 +560,7 @@ resource "packet_device" "test_ipxe_script_url"  {
 
   hostname         = "test-ipxe-script-url"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "custom_ipxe"
   user_data        = "#!/bin/sh\ntouch /tmp/test"
   billing_cycle    = "hourly"
@@ -615,7 +578,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test_ipxe_conflict" {
   hostname         = "test-ipxe-conflict"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "custom_ipxe"
   user_data        = "#!ipxe\nset conflict ipxe_script_url"
   billing_cycle    = "hourly"
@@ -632,7 +595,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test_ipxe_missing" {
   hostname         = "test-ipxe-missing"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"

--- a/packet/resource_packet_ip_attachment_test.go
+++ b/packet/resource_packet_ip_attachment_test.go
@@ -62,7 +62,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -21,7 +21,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facility         = "dfw2"
+  facilities       = ["dfw2"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -89,7 +89,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facility         = "dfw2"
+  facilities       = ["dfw2"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -157,7 +157,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facility         = "dfw2"
+  facilities       = ["dfw2"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -26,7 +26,7 @@ resource "packet_project_ssh_key" "test" {
 resource "packet_device" "test" {
     hostname            = "test"
     plan                = "baremetal_0"
-    facility            = "ewr1"
+    facilities          = ["ewr1"]
     operating_system    = "ubuntu_16_04"
     billing_cycle       = "hourly"
     project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]

--- a/website/docs/d/operating_system.html.markdown
+++ b/website/docs/d/operating_system.html.markdown
@@ -23,7 +23,7 @@ data "packet_operating_system" "example" {
 resource "packet_device" "server" {
   hostname         = "tf.coreos2"
   plan             = "c1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "${data.packet_operating_system.example.id}"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"

--- a/website/docs/d/precreated_ip_block.html.markdown
+++ b/website/docs/d/precreated_ip_block.html.markdown
@@ -26,7 +26,7 @@ locals {
 resource "packet_device" "web1" {
   hostname         = "web1"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"

--- a/website/docs/r/bgp_session.html.markdown
+++ b/website/docs/r/bgp_session.html.markdown
@@ -49,7 +49,7 @@ resource "packet_reserved_ip_block" "addr" {
 resource "packet_device" "test" {
   hostname         = "terraform-test-bgp-sesh"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -23,7 +23,7 @@ modify, and delete devices.
 resource "packet_device" "web1" {
   hostname         = "tf.coreos2"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "coreos_stable"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"
@@ -35,7 +35,7 @@ resource "packet_device" "web1" {
 resource "packet_device" "pxe1" {
   hostname         = "tf.coreos2-pxe"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "custom_ipxe"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"
@@ -50,7 +50,7 @@ resource "packet_device" "pxe1" {
 resource "packet_device" "web1" {
   hostname         = "tftest"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"
@@ -120,7 +120,6 @@ The following arguments are supported:
 * `hostname` - (Required) The device name
 * `project_id` - (Required) The id of the project in which to create the device
 * `operating_system` - (Required) The operating system slug. To find the slug, or visit [Operating Systems API docs](https://www.packet.com/developers/api/#operatingsystems), set your API auth token in the top of the page and see JSON from the API response.
-* `facility` - (Deprecated) The facility in which to create the device.
 * `facilities` - List of facility codes with deployment preferences. Packet API will go through the list and will deploy your device to first facility with free capacity. List items must be facility codes or `any` (a wildcard). To find the facility code, visit [Facilities API docs](https://www.packet.com/developers/api/#facilities), set your API auth token in the top of the page and see JSON from the API response.
 * `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.com/developers/api/#plans), set your auth token in the top of the page and see JSON from the API response.
 * `billing_cycle` - (Required) monthly or hourly
@@ -148,7 +147,7 @@ The following attributes are exported:
 * `id` - The ID of the device
 * `hostname`- The hostname of the device
 * `project_id`- The ID of the project the device belongs to
-* `facility` - The facility where the device is deployed.
+* `deployed_facility` - The facility where the device is deployed.
 * `plan` - The hardware config of the device
 * `network` - The device's private and public IP (v4 and v6) network details. When a device is run without any special network configuration, it will have 3 networks: 
   * Public IPv4 at `packet_device.name.network.0`

--- a/website/docs/r/port_vlan_attachment.html.markdown
+++ b/website/docs/r/port_vlan_attachment.html.markdown
@@ -51,7 +51,7 @@ resource "packet_port_vlan_attachment" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "m1.xlarge.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"

--- a/website/docs/r/project_ssh_key.html.markdown
+++ b/website/docs/r/project_ssh_key.html.markdown
@@ -29,7 +29,7 @@ resource "packet_project_ssh_key" "test" {
 resource "packet_device" "test" {
   hostname            = "test"
   plan                = "baremetal_0"
-  facility            = "ewr1"
+  facilities          = ["ewr1"]
   operating_system    = "ubuntu_16_04"
   billing_cycle       = "hourly"
   project_ssh_key_ids = ["${packet_project_ssh_key.test.id}"]

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -26,7 +26,7 @@ resource "packet_ssh_key" "key1" {
 resource "packet_device" "test" {
   hostname         = "test-device"
   plan             = "t1.small.x86"
-  facility         = "sjc1"
+  facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"

--- a/website/docs/r/volume_attachment.html.markdown
+++ b/website/docs/r/volume_attachment.html.markdown
@@ -20,7 +20,7 @@ Once attached by Terraform, they must then be mounted using the `packet_block_at
 resource "packet_device" "test_device_va" {
   hostname         = "terraform-test-device-va"
   plan             = "t1.small.x86"
-  facility         = "ewr1"
+  facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${local.project_id}"


### PR DESCRIPTION
This PR removes `facility` attr in favor of more general `facilities` (taking advantage of dynamically specified deployment location). 

It also adds a Computed attr `deployed_facility` to the packet_device resource

Fixes #141 