### PR TITLE
Add field for selecting IP Address types when creating device

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -70,6 +70,7 @@ func resourcePacketDevice() *schema.Resource {
 					ValidateFunc: validation.StringInSlice([]string{"public_ipv4", "private_ipv4", "public_ipv6"}, false),
 				},
 				MaxItems: 3,
+				MinItems: 1,
 				ForceNew: true,
 			},
 			"facilities": {

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -139,6 +139,7 @@ The following arguments are supported:
 * `description` - Description string for the device
 * `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][packet_project_ssh_key.html] resource.
 * `network_type` (Optional) - Network type of device, used for [Layer 2 networking](https://support.packet.com/kb/articles/layer-2-overview). Allowed values are `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`. If you keep it empty, Terraform will not handle the network type of the device.
+* `ip_address_types` (Optional) - A set containing one or more of [`private_ipv4`, `public_ipv4`, `public_ipv6`]. It specifies which IP address types a new device should obtain. If omitted, a created device will obtain all 3 addresses. If you only want private IPv4 address for the new device, pass [`private_ipv4`].
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds functionality allowing users to select which IP address type a new device should have.

It's mainly to enable provisioning devices without public IP addresses.