### PR TITLE
resource/packet_port_vlan_attachment: Avoid parallel assignment

### DIFF
--- a/packet/provider.go
+++ b/packet/provider.go
@@ -3,11 +3,13 @@ package packet
 import (
 	"time"
 
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-// Provider returns a schema.Provider for managing Packet infrastructure.
+var packetMutexKV = mutexkv.NewMutexKV()
+
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{

--- a/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
+++ b/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
@@ -1,0 +1,51 @@
+package mutexkv
+
+import (
+	"log"
+	"sync"
+)
+
+// MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
+// serialize changes across arbitrary collaborators that share knowledge of the
+// keys they must serialize on.
+//
+// The initial use case is to let aws_security_group_rule resources serialize
+// their access to individual security groups based on SG ID.
+type MutexKV struct {
+	lock  sync.Mutex
+	store map[string]*sync.Mutex
+}
+
+// Locks the mutex for the given key. Caller is responsible for calling Unlock
+// for the same key
+func (m *MutexKV) Lock(key string) {
+	log.Printf("[DEBUG] Locking %q", key)
+	m.get(key).Lock()
+	log.Printf("[DEBUG] Locked %q", key)
+}
+
+// Unlock the mutex for the given key. Caller must have called Lock for the same key first
+func (m *MutexKV) Unlock(key string) {
+	log.Printf("[DEBUG] Unlocking %q", key)
+	m.get(key).Unlock()
+	log.Printf("[DEBUG] Unlocked %q", key)
+}
+
+// Returns a mutex for the given key, no guarantee of its lock status
+func (m *MutexKV) get(key string) *sync.Mutex {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	mutex, ok := m.store[key]
+	if !ok {
+		mutex = &sync.Mutex{}
+		m.store[key] = mutex
+	}
+	return mutex
+}
+
+// Returns a properly initalized MutexKV
+func NewMutexKV() *MutexKV {
+	return &MutexKV{
+		store: make(map[string]*sync.Mutex),
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -113,6 +113,7 @@ github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.12.0-alpha4.0.20190424121927-9327eedb0417
 github.com/hashicorp/terraform/plugin
 github.com/hashicorp/terraform/helper/logging
+github.com/hashicorp/terraform/helper/mutexkv
 github.com/hashicorp/terraform/helper/resource
 github.com/hashicorp/terraform/helper/schema
 github.com/hashicorp/terraform/helper/structure


### PR DESCRIPTION
Packet's API reports HTTP 500 Internal Server Error when 2+ requests are issued for assigning a VLAN to a port in parallel, as demonstrated by attached test suite.

I have already contacted Packet support and they said the API doesn't support parallel assignment at this point and they agreed the API should respond 4xx instead of 5xx in such cases. They plan to fix the API in that sense, but implementation/allowing parallel execution may take more time.

I'm therefore adding mutex to avoid parallel VLAN assignments until this is actually fixed/implemented.

### Before

```
$ make testacc TEST=./packet TESTARGS='-run=TestAccPacketPortVlanAttachment_HybridMultipleVlans'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./packet -v -run=TestAccPacketPortVlanAttachment_HybridMultipleVlans -timeout 120m
=== RUN   TestAccPacketPortVlanAttachment_HybridMultipleVlans
--- FAIL: TestAccPacketPortVlanAttachment_HybridMultipleVlans (180.58s)
    testing.go:568: Step 0 error: errors during apply:

        Error: POST https://api.packet.net/ports/4746fa57-fded-46ad-8cf1-b4c0f34affc8/assign: 500 Oh snap, something went wrong! We've logged the error and will take a look - please reach out to us if you continue having trouble.

          on /var/folders/31/hkndp1hj17s_kp632xk19j1h0000gn/T/tf-test887383766/main.tf line 23:
          (source code not available)



        Error: POST https://api.packet.net/ports/4746fa57-fded-46ad-8cf1-b4c0f34affc8/assign: 500 Oh snap, something went wrong! We've logged the error and will take a look - please reach out to us if you continue having trouble.

          on /var/folders/31/hkndp1hj17s_kp632xk19j1h0000gn/T/tf-test887383766/main.tf line 23:
          (source code not available)


FAIL
FAIL	github.com/terraform-providers/terraform-provider-packet/packet	180.611s
make: *** [testacc] Error 1
```

### After

```
$ make testacc TEST=./packet TESTARGS='-run=TestAccPacketPortVlanAttachment_HybridMultipleVlans'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./packet -v -run=TestAccPacketPortVlanAttachment_HybridMultipleVlans -timeout 120m
=== RUN   TestAccPacketPortVlanAttachment_HybridMultipleVlans
--- PASS: TestAccPacketPortVlanAttachment_HybridMultipleVlans (292.21s)
PASS
ok  	github.com/terraform-providers/terraform-provider-packet/packet	292.240s
```