### PR TITLE
Rework operating systems datasource filtering and add tests

### DIFF
--- a/packet/datasource_packet_operating_system.go
+++ b/packet/datasource_packet_operating_system.go
@@ -58,73 +58,60 @@ func dataSourcePacketOperatingSystemRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	final := []packngo.OS{}
-	temp := []packngo.OS{}
-
 	if nameOK {
+		temp := []packngo.OS{}
 		for _, os := range oss {
 			if strings.Contains(strings.ToLower(os.Name), strings.ToLower(name.(string))) {
 				temp = append(temp, os)
 			}
-			final = temp
 		}
+		oss = temp
 	}
 
-	if distroOK {
-		temp = []packngo.OS{}
-		if len(temp) == 0 {
-			final = oss
-		}
-		for _, v := range final {
+	if distroOK && (len(oss) != 0) {
+		temp := []packngo.OS{}
+		for _, v := range oss {
 			if v.Distro == distro.(string) {
 				temp = append(temp, v)
 			}
 		}
-		final = temp
+		oss = temp
 	}
 
-	if versionOK {
-		temp = []packngo.OS{}
-		if len(final) == 0 {
-			final = oss
-		}
-		for _, v := range final {
+	if versionOK && (len(oss) != 0) {
+		temp := []packngo.OS{}
+		for _, v := range oss {
 			if v.Version == version.(string) {
 				temp = append(temp, v)
 			}
 		}
-		final = temp
+		oss = temp
 	}
 
-	if provisionableOnOK {
-		temp = []packngo.OS{}
-		if len(final) == 0 {
-			final = oss
-		}
-		for _, v := range final {
+	if provisionableOnOK && (len(oss) != 0) {
+		temp := []packngo.OS{}
+		for _, v := range oss {
 			for _, po := range v.ProvisionableOn {
 				if po == provisionableOn.(string) {
 					temp = append(temp, v)
 				}
 			}
 		}
-		final = temp
+		oss = temp
 	}
-	log.Println("[DEBUG] RESULTS:", final)
+	log.Println("[DEBUG] RESULTS:", oss)
 
-	if len(final) == 0 {
+	if len(oss) == 0 {
 		return fmt.Errorf("There are no operating systems that match the search criteria")
 	}
 
-	if len(final) > 1 {
+	if len(oss) > 1 {
 		return fmt.Errorf("There is more than one operating system that matches the search criteria")
 	}
-	for _, v := range final {
-		d.Set("name", v.Name)
-		d.Set("distro", v.Distro)
-		d.Set("version", v.Version)
-		d.Set("slug", v.Slug)
-		d.SetId(v.Slug)
-	}
+	d.Set("name", oss[0].Name)
+	d.Set("distro", oss[0].Distro)
+	d.Set("version", oss[0].Version)
+	d.Set("slug", oss[0].Slug)
+	d.SetId(oss[0].Slug)
 	return nil
 }

--- a/packet/datasource_packet_operating_system_test.go
+++ b/packet/datasource_packet_operating_system_test.go
@@ -1,6 +1,7 @@
 package packet
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -26,4 +27,46 @@ const testOperatingSystemConfig_Basic = `
 		name    = "Container"
 		distro  = "coreos"
 		version = "alpha"
+	  }`
+
+var matchErrOSNotFound = regexp.MustCompile(".*There are no operating systems*")
+
+func TestAccPacketOperatingSystem_NotFound(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{Config: testOperatingSystemConfig_NotFound,
+				ExpectError: matchErrOSNotFound,
+			},
+		},
+	})
+}
+
+const testOperatingSystemConfig_NotFound = `
+	data "packet_operating_system" "example" {
+		name    = "Container"
+		distro  = "NOTEXISTS"
+		version = "alpha"
+	  }`
+
+var matchErrOSAmbiguous = regexp.MustCompile(".*There is more than one operating system.*")
+
+func TestAccPacketOperatingSystem_Ambiguous(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{Config: testOperatingSystemConfig_Ambiguous,
+				ExpectError: matchErrOSAmbiguous,
+			},
+		},
+	})
+}
+
+const testOperatingSystemConfig_Ambiguous = `
+	data "packet_operating_system" "example" {
+		distro  = "ubuntu"
 	  }`


### PR DESCRIPTION
This PR reworks the OS datasource filtering and add tests for the case reported in #155.

Fixes #155 