### PR TITLE
Clean up acceptance test naming

### DIFF
--- a/packet/datasource_packet_precreated_ip_block_test.go
+++ b/packet/datasource_packet_precreated_ip_block_test.go
@@ -39,7 +39,7 @@ func testPreCreatedIPBlockConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "packet_project" "test" {
-    name = "%s"
+    name = "tfacc-precreated_ip_block-%s"
 }
 
 resource "packet_device" "test" {

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -18,7 +18,7 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPacketBGPSessionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPacketBGPSessionConfig_basic(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
@@ -28,7 +28,7 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 						"packet_bgp_session.test", "default_route", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "packet_bgp_session.test",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -55,7 +55,7 @@ func testAccCheckPacketBGPSessionDestroy(s *terraform.State) error {
 func testAccCheckPacketBGPSessionConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "%s"
+    name = "tfacc-bgp_session-%s"
 	bgp_config {
 		deployment_type = "local"
 		md5 = "C179c28c41a85b"

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -135,7 +135,7 @@ func resourcePacketDevice() *schema.Resource {
 				Computed: true,
 			},
 
-			"network_type": &schema.Schema{
+			"network_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"layer3", "layer2-bonded", "layer2-individual", "hybrid"}, false),
@@ -147,28 +147,28 @@ func resourcePacketDevice() *schema.Resource {
 				},
 			},
 
-			"ports": &schema.Schema{
+			"ports": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"id": &schema.Schema{
+						"id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"mac": &schema.Schema{
+						"mac": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"bonded": &schema.Schema{
+						"bonded": {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -203,7 +203,7 @@ func TestAccPacketDevice_IPXEScriptUrl(t *testing.T) {
 func testAccCheckPacketDeviceConfig_L2(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test" {
@@ -446,7 +446,7 @@ func TestAccPacketDevice_importBasic(t *testing.T) {
 func testAccCheckPacketDeviceConfig_no_description(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test" {
@@ -464,7 +464,7 @@ resource "packet_device" "test" {
 func testAccCheckPacketDeviceConfig_varname(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test" {
@@ -483,7 +483,7 @@ resource "packet_device" "test" {
 func testAccCheckPacketDeviceConfig_varname_pxe(rInt int, projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test" {
@@ -504,7 +504,7 @@ resource "packet_device" "test" {
 func testAccCheckPacketDeviceConfig_basic(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test" {
@@ -519,7 +519,7 @@ resource "packet_device" "test" {
 
 var testAccCheckPacketDeviceConfig_request_subnet = `
 resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
+  name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test_subnet_29" {
@@ -536,7 +536,7 @@ resource "packet_device" "test_subnet_29" {
 func testAccCheckPacketDeviceConfig_facility_list(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
+  name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test"  {
@@ -553,7 +553,7 @@ resource "packet_device" "test"  {
 func testAccCheckPacketDeviceConfig_ipxe_script_url(projSuffix, url, pxe string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
+  name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test_ipxe_script_url"  {
@@ -572,7 +572,7 @@ resource "packet_device" "test_ipxe_script_url"  {
 
 var testAccCheckPacketDeviceConfig_ipxe_conflict = `
 resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
+  name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test_ipxe_conflict" {
@@ -589,7 +589,7 @@ resource "packet_device" "test_ipxe_conflict" {
 
 var testAccCheckPacketDeviceConfig_ipxe_missing = `
 resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
+  name = "tfacc-device-%s"
 }
 
 resource "packet_device" "test_ipxe_missing" {

--- a/packet/resource_packet_ip_attachment_test.go
+++ b/packet/resource_packet_ip_attachment_test.go
@@ -56,7 +56,7 @@ func testAccCheckPacketIPAttachmentDestroy(s *terraform.State) error {
 func testAccCheckPacketIPAttachmentConfig_Basic(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "%s"
+    name = "tfacc-ip_attachment-%s"
 }
 
 resource "packet_device" "test" {

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -15,7 +15,7 @@ import (
 func testAccCheckPacketPortVlanAttachmentConfig_L2Bonded(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-port_vlan_attachment-%s"
 }
 
 resource "packet_device" "test" {
@@ -83,7 +83,7 @@ func TestAccPacketPortVlanAttachment_L2Bonded(t *testing.T) {
 func testAccCheckPacketPortVlanAttachmentConfig_L2Individual(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-port_vlan_attachment-%s"
 }
 
 resource "packet_device" "test" {
@@ -151,7 +151,7 @@ func TestAccPacketPortVlanAttachment_L2Individual(t *testing.T) {
 func testAccCheckPacketPortVlanAttachmentConfig_Hybrid(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-port_vlan_attachment-%s"
 }
 
 resource "packet_device" "test" {
@@ -203,7 +203,7 @@ func TestAccPacketPortVlanAttachment_Hybrid(t *testing.T) {
 func testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-  name = "TerraformTestProject-%s"
+  name = "tfacc-port_vlan_attachment-%s"
 }
 
 resource "packet_device" "test" {
@@ -299,7 +299,7 @@ func testAccCheckPacketPortVlanAttachmentDestroy(s *terraform.State) error {
 func testAccCheckPacketPortVlanAttachmentConfig_L2Native(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-port_vlan_attachment-%s"
 }
 
 resource "packet_device" "test" {

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -64,30 +64,30 @@ func resourcePacketProject() *schema.Resource {
 				},
 				ValidateFunc: validation.StringMatch(uuidRE, "must be a valid UUID"),
 			},
-			"bgp_config": &schema.Schema{
+			"bgp_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"deployment_type": &schema.Schema{
+						"deployment_type": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{"local", "global"}, false),
 						},
-						"asn": &schema.Schema{
+						"asn": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
-						"md5": &schema.Schema{
+						"md5": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"status": &schema.Schema{
+						"status": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"max_prefix": &schema.Schema{
+						"max_prefix": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func packetProjectSSHKeyConfig_Basic(publicSshKey string) string {
+func packetProjectSSHKeyConfig_Basic(name, publicSshKey string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "test"
+    name = "tfacc-project_ssh_key-%s"
 }
 
 resource "packet_project_ssh_key" "test" {
@@ -33,16 +33,17 @@ resource "packet_device" "test" {
     project_id          = "${packet_project.test.id}"
 }
 
-`, publicSshKey)
+`, name, publicSshKey)
 }
 
 func TestAccPacketProjectSSHKey_Basic(t *testing.T) {
+	rs := acctest.RandString(10)
 	var key packngo.SSHKey
 	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("")
 	if err != nil {
 		t.Fatalf("Cannot generate test SSH key pair: %s", err)
 	}
-	cfg := packetProjectSSHKeyConfig_Basic(publicKeyMaterial)
+	cfg := packetProjectSSHKeyConfig_Basic(rs, publicKeyMaterial)
 	log.Printf(cfg)
 
 	resource.Test(t, resource.TestCase{

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -25,7 +25,7 @@ func TestAccPacketProject_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),
 					resource.TestCheckResourceAttr(
-						"packet_project.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
+						"packet_project.foobar", "name", fmt.Sprintf("tfacc-project-%d", rInt)),
 				),
 			},
 		},
@@ -105,7 +105,7 @@ func TestAccPacketProject_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),
 					resource.TestCheckResourceAttr(
-						"packet_project.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
+						"packet_project.foobar", "name", fmt.Sprintf("tfacc-project-%d", rInt)),
 				),
 			},
 			{
@@ -113,7 +113,7 @@ func TestAccPacketProject_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),
 					resource.TestCheckResourceAttr(
-						"packet_project.foobar", "name", fmt.Sprintf("foobar-%d", rInt+1)),
+						"packet_project.foobar", "name", fmt.Sprintf("tfacc-project-%d", rInt+1)),
 				),
 			},
 		},
@@ -215,7 +215,7 @@ func testAccCheckPacketProjectExists(n string, project *packngo.Project) resourc
 func testAccCheckPacketProjectConfig_BT(r int) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "foobar-%d"
+    name = "tfacc-project-%d"
 	backend_transfer = true
 }`, r)
 }
@@ -223,14 +223,14 @@ resource "packet_project" "foobar" {
 func testAccCheckPacketProjectConfig_basic(r int) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "foobar-%d"
+    name = "tfacc-project-%d"
 }`, r)
 }
 
 func testAccCheckPacketProjectConfig_BGP(r int, pass string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "foobar-%d"
+    name = "tfacc-project-%d"
 	bgp_config {
 		deployment_type = "local"
 		md5 = "%s"
@@ -242,11 +242,11 @@ resource "packet_project" "foobar" {
 func testAccCheckPacketProjectOrgConfig(r string) string {
 	return fmt.Sprintf(`
 resource "packet_organization" "test" {
-	name = "foobar-%s"
+	name = "tfacc-project-%s"
 }
 
 resource "packet_project" "foobar" {
-		name = "foobar-%s"
+		name = "tfacc-project-%s"
 		organization_id = "${packet_organization.test.id}"
 }`, r, r)
 }
@@ -265,7 +265,7 @@ func TestAccPacketProjectOrg(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),
 					resource.TestCheckResourceAttr(
-						"packet_project.foobar", "name", fmt.Sprintf("foobar-%s", rn)),
+						"packet_project.foobar", "name", fmt.Sprintf("tfacc-project-%s", rn)),
 				),
 			},
 		},

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -41,7 +41,7 @@ func TestAccPacketProject_BGPBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPacketProjectDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPacketProjectConfig_BGP(rInt, "2SFsdfsg43"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketProjectExists("packet_project.foobar", &project),

--- a/packet/resource_packet_reserved_ip_block_test.go
+++ b/packet/resource_packet_reserved_ip_block_test.go
@@ -13,7 +13,7 @@ import (
 func testAccCheckPacketReservedIPBlockConfig_Global(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "%s"
+    name = "tfacc-reserved_ip_block-%s"
 }
 
 resource "packet_reserved_ip_block" "test" {
@@ -26,7 +26,7 @@ resource "packet_reserved_ip_block" "test" {
 func testAccCheckPacketReservedIPBlockConfig_Public(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "%s"
+    name = "tfacc-reserved_ip_block-%s"
 }
 
 resource "packet_reserved_ip_block" "test" {

--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/packethost/packngo"
@@ -11,6 +12,7 @@ import (
 
 func TestAccPacketSpotMarketRequest_Basic(t *testing.T) {
 	var key packngo.SpotMarketRequest
+	rs := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +20,7 @@ func TestAccPacketSpotMarketRequest_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckPacketSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketSpotMarketRequestConfig_basic,
+				Config: testAccCheckPacketSpotMarketRequestConfig_basic(rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketSpotMarketRequestExists("packet_spot_market_request.request", &key),
 					resource.TestCheckResourceAttr("packet_spot_market_request.request", "devices_max", "1"),
@@ -71,23 +73,25 @@ func testAccCheckPacketSpotMarketRequestExists(n string, key *packngo.SpotMarket
 	}
 }
 
-var testAccCheckPacketSpotMarketRequestConfig_basic = `
-	  resource "packet_project" "test" {
-		name = "TerraformTestProject-SMR"
-	  }
-	  
-	  resource "packet_spot_market_request" "request" {
-		project_id       = "${packet_project.test.id}"
-		max_bid_price    = 0.03
-		facilities       = ["ewr1"]
-		devices_min      = 1
-		devices_max      = 1
-		wait_for_devices = true
+func testAccCheckPacketSpotMarketRequestConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "packet_project" "test" {
+  name = "tfacc-spot_market_request-%s"
+}
 
-		instance_parameters {
-		  hostname         = "testspot"
-		  billing_cycle    = "hourly"
-		  operating_system = "coreos_stable"
-		  plan             = "t1.small.x86"
-		}
-	  }`
+resource "packet_spot_market_request" "request" {
+  project_id       = "${packet_project.test.id}"
+  max_bid_price    = 0.03
+  facilities       = ["ewr1"]
+  devices_min      = 1
+  devices_max      = 1
+  wait_for_devices = true
+
+  instance_parameters {
+    hostname         = "testspot"
+    billing_cycle    = "hourly"
+    operating_system = "coreos_stable"
+    plan             = "t1.small.x86"
+  }
+}`, name)
+}

--- a/packet/resource_packet_vlan_test.go
+++ b/packet/resource_packet_vlan_test.go
@@ -78,7 +78,7 @@ func testAccCheckPacketVlanDestroyed(s *terraform.State) error {
 func testAccCheckPacketVlanConfig_var(projSuffix, facility, desc string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-vlan-%s"
 }
 
 resource "packet_vlan" "foovlan" {

--- a/packet/resource_packet_volume_attachment_test.go
+++ b/packet/resource_packet_volume_attachment_test.go
@@ -56,7 +56,7 @@ func testAccCheckPacketVolumeAttachmentDestroy(s *terraform.State) error {
 func testAccCheckPacketVolumeAttachmentConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "%s"
+    name = "tfacc-volume_attachment-%s"
 }
 
 resource "packet_device" "test" {

--- a/packet/resource_packet_volume_test.go
+++ b/packet/resource_packet_volume_test.go
@@ -176,7 +176,7 @@ func testAccCheckPacketVolumeExists(n string, volume *packngo.Volume) resource.T
 func testAccCheckPacketVolumeConfig_basic(projectSuffix string) string {
 	return fmt.Sprintf(
 		`resource "packet_project" "foobar" {
-    name = "%s"
+    name = "tfacc-volume-%s"
 }
 
 resource "packet_volume" "foobar" {
@@ -195,7 +195,7 @@ resource "packet_volume" "foobar" {
 func testAccCheckPacketVolumeConfig_var(projSuffix string, size int, desc string, planID string, locked bool) string {
 	return fmt.Sprintf(`
 resource "packet_project" "foobar" {
-    name = "TerraformTestProject-%s"
+    name = "tfacc-volume-%s"
 }
 
 resource "packet_volume" "foobar" {


### PR DESCRIPTION
Updating project naming to make cleanup easier, and leaky tests more apparent.