### PR TITLE
Datasource for spot market request

### DIFF
--- a/packet/datasource_packet_device_test.go
+++ b/packet/datasource_packet_device_test.go
@@ -57,3 +57,52 @@ data "packet_device" "test" {
   hostname         = packet_device.test.hostname
 }`, projSuffix)
 }
+
+func TestAccDataSourcePacketDevice_ByID(t *testing.T) {
+	projectName := fmt.Sprintf("ds-device-by-id-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketDeviceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePacketDeviceConfig_ByID(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.packet_device.test", "hostname", "test-device"),
+					resource.TestCheckResourceAttrPair(
+						"packet_device.test", "id",
+						"data.packet_device.test", "id"),
+					resource.TestCheckResourceAttrPair(
+						"packet_device.test", "operating_system",
+						"data.packet_device.test", "operating_system"),
+					resource.TestCheckResourceAttr(
+						"data.packet_device.test", "always_pxe", "false"),
+					resource.TestCheckResourceAttrSet(
+						"data.packet_device.test", "access_public_ipv4"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePacketDeviceConfig_ByID(projSuffix string) string {
+	return fmt.Sprintf(`
+resource "packet_project" "test" {
+    name = "tfacc-project-%s"
+}
+
+resource "packet_device" "test" {
+  hostname         = "test-device"
+  plan             = "t1.small.x86"
+  facilities       = ["sjc1"]
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = "${packet_project.test.id}"
+}
+
+data "packet_device" "test" {
+  device_id       = packet_device.test.id
+}`, projSuffix)
+}

--- a/packet/datasource_packet_spot_market_request.go
+++ b/packet/datasource_packet_spot_market_request.go
@@ -1,0 +1,311 @@
+package packet
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func resourcePacketSpotMarketRequest() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePacketSpotMarketRequestCreate,
+		Read:   resourcePacketSpotMarketRequestRead,
+		Delete: resourcePacketSpotMarketRequestDelete,
+
+		Schema: map[string]*schema.Schema{
+			"devices_min": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"devices_max": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"max_bid_price": {
+				Type:     schema.TypeFloat,
+				Required: true,
+				ForceNew: true,
+			},
+			"facilities": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+			},
+			"instance_parameters": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"billing_cycle": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"plan": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"operating_system": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"hostname": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"termintation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"always_pxe": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"features": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"locked": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"project_ssh_keys": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"user_ssh_keys": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"userdata": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"wait_for_devices": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+		Timeouts: resourceDefaultTimeouts,
+	}
+}
+
+func resourcePacketSpotMarketRequestCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	var waitForDevices bool
+
+	facilitiesRaw := d.Get("facilities").([]interface{})
+	facilities := []string{}
+
+	for _, f := range facilitiesRaw {
+		facilities = append(facilities, f.(string))
+	}
+
+	params := packngo.SpotMarketRequestInstanceParameters{
+		Hostname:        d.Get("instance_parameters.0.hostname").(string),
+		BillingCycle:    d.Get("instance_parameters.0.billing_cycle").(string),
+		Plan:            d.Get("instance_parameters.0.plan").(string),
+		OperatingSystem: d.Get("instance_parameters.0.operating_system").(string),
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.userdata"); ok {
+		params.UserData = val.(string)
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.always_pxe"); ok {
+		params.AlwaysPXE = val.(bool)
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.description"); ok {
+		params.Description = val.(string)
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.features"); ok {
+		temp := val.([]interface{})
+		for _, i := range temp {
+			if i != nil {
+				params.Features = append(params.Features, i.(string))
+			}
+		}
+	}
+
+	if val, ok := d.GetOk("wait_for_devices"); ok {
+		waitForDevices = val.(bool)
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.locked"); ok {
+		params.Locked = val.(bool)
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.project_ssh_keys"); ok {
+		temp := val.([]interface{})
+		for _, i := range temp {
+			if i != nil {
+				params.ProjectSSHKeys = append(params.ProjectSSHKeys, i.(string))
+			}
+		}
+	}
+
+	if val, ok := d.GetOk("instance_parameters.0.user_ssh_keys"); ok {
+		temp := val.([]interface{})
+		for _, i := range temp {
+			if i != nil {
+				params.UserSSHKeys = append(params.UserSSHKeys, i.(string))
+			}
+		}
+	}
+
+	smrc := &packngo.SpotMarketRequestCreateRequest{
+		DevicesMax:  d.Get("devices_max").(int),
+		DevicesMin:  d.Get("devices_min").(int),
+		MaxBidPrice: d.Get("max_bid_price").(float64),
+		FacilityIDs: facilities,
+		Parameters:  params,
+	}
+
+	smr, _, err := client.SpotMarketRequests.Create(smrc, d.Get("project_id").(string))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(smr.ID)
+
+	if waitForDevices {
+		stateConf := &resource.StateChangeConf{
+			Pending:        []string{"not_done"},
+			Target:         []string{"done"},
+			Refresh:        resourceStateRefreshFunc(d, meta),
+			Timeout:        d.Timeout(schema.TimeoutCreate),
+			MinTimeout:     5 * time.Second,
+			Delay:          3 * time.Second, // Wait 10 secs before starting
+			NotFoundChecks: 600,             //Setting high number, to support long timeouts
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourcePacketSpotMarketRequestRead(d, meta)
+}
+
+func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
+	if err != nil {
+		err = friendlyError(err)
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	deviceIDs := make([]string, len(smr.Devices))
+	for i, d := range smr.Devices {
+		deviceIDs[i] = d.ID
+	}
+
+	facilityIDs := make([]string, len(smr.Facilities))
+	if len(smr.Facilities) > 0 {
+		for i, f := range smr.Facilities {
+			facilityIDs[i] = f.ID
+		}
+	}
+	d.Set("project_id", smr.Project.ID)
+
+	return nil
+}
+
+func resourcePacketSpotMarketRequestDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	var waitForDevices bool
+
+	if val, ok := d.GetOk("wait_for_devices"); ok {
+		waitForDevices = val.(bool)
+	}
+	if waitForDevices {
+		smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
+		if err != nil {
+			return nil
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:        []string{"not_done"},
+			Target:         []string{"done"},
+			Refresh:        resourceStateRefreshFunc(d, meta),
+			Timeout:        d.Timeout(schema.TimeoutDelete),
+			MinTimeout:     5 * time.Second,
+			Delay:          3 * time.Second, // Wait 10 secs before starting
+			NotFoundChecks: 600,             //Setting high number, to support long timeouts
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return err
+		}
+
+		for _, d := range smr.Devices {
+			_, err := client.Devices.Delete(d.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	_, err := client.SpotMarketRequests.Delete(d.Id(), true)
+	if err != nil {
+		return nil
+	}
+	return nil
+}
+
+func resourceStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		client := meta.(*packngo.Client)
+		smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
+
+		if err != nil {
+			return nil, "", err
+
+		}
+		var finished bool
+
+		for _, d := range smr.Devices {
+
+			dev, _, _ := client.Devices.Get(d.ID, nil)
+			if dev.State != "active" {
+				break
+			} else {
+				finished = true
+			}
+		}
+		if finished {
+			return smr, "done", nil
+		}
+		return nil, "not_done", nil
+	}
+}

--- a/packet/datasource_packet_spot_market_request.go
+++ b/packet/datasource_packet_spot_market_request.go
@@ -1,221 +1,33 @@
 package packet
 
 import (
-	"time"
-
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/packethost/packngo"
 )
 
-func resourcePacketSpotMarketRequest() *schema.Resource {
+func dataSourcePacketSpotMarketRequest() *schema.Resource {
 	return &schema.Resource{
-		Create: resourcePacketSpotMarketRequestCreate,
-		Read:   resourcePacketSpotMarketRequestRead,
-		Delete: resourcePacketSpotMarketRequestDelete,
+		Read: dataSourcePacketSpotMarketRequestRead,
 
 		Schema: map[string]*schema.Schema{
-			"devices_min": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"devices_max": {
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-			"max_bid_price": {
-				Type:     schema.TypeFloat,
-				Required: true,
-				ForceNew: true,
-			},
-			"facilities": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				ForceNew: true,
-			},
-			"instance_parameters": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"billing_cycle": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"plan": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"operating_system": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"hostname": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"termintation_time": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"always_pxe": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"features": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"locked": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"project_ssh_keys": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"user_ssh_keys": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"userdata": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
-			},
-			"project_id": {
+			"request_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
-			"wait_for_devices": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
+			"device_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 		Timeouts: resourceDefaultTimeouts,
 	}
 }
-
-func resourcePacketSpotMarketRequestCreate(d *schema.ResourceData, meta interface{}) error {
+func dataSourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*packngo.Client)
-	var waitForDevices bool
+	id := d.Get("request_id").(string)
 
-	facilitiesRaw := d.Get("facilities").([]interface{})
-	facilities := []string{}
-
-	for _, f := range facilitiesRaw {
-		facilities = append(facilities, f.(string))
-	}
-
-	params := packngo.SpotMarketRequestInstanceParameters{
-		Hostname:        d.Get("instance_parameters.0.hostname").(string),
-		BillingCycle:    d.Get("instance_parameters.0.billing_cycle").(string),
-		Plan:            d.Get("instance_parameters.0.plan").(string),
-		OperatingSystem: d.Get("instance_parameters.0.operating_system").(string),
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.userdata"); ok {
-		params.UserData = val.(string)
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.always_pxe"); ok {
-		params.AlwaysPXE = val.(bool)
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.description"); ok {
-		params.Description = val.(string)
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.features"); ok {
-		temp := val.([]interface{})
-		for _, i := range temp {
-			if i != nil {
-				params.Features = append(params.Features, i.(string))
-			}
-		}
-	}
-
-	if val, ok := d.GetOk("wait_for_devices"); ok {
-		waitForDevices = val.(bool)
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.locked"); ok {
-		params.Locked = val.(bool)
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.project_ssh_keys"); ok {
-		temp := val.([]interface{})
-		for _, i := range temp {
-			if i != nil {
-				params.ProjectSSHKeys = append(params.ProjectSSHKeys, i.(string))
-			}
-		}
-	}
-
-	if val, ok := d.GetOk("instance_parameters.0.user_ssh_keys"); ok {
-		temp := val.([]interface{})
-		for _, i := range temp {
-			if i != nil {
-				params.UserSSHKeys = append(params.UserSSHKeys, i.(string))
-			}
-		}
-	}
-
-	smrc := &packngo.SpotMarketRequestCreateRequest{
-		DevicesMax:  d.Get("devices_max").(int),
-		DevicesMin:  d.Get("devices_min").(int),
-		MaxBidPrice: d.Get("max_bid_price").(float64),
-		FacilityIDs: facilities,
-		Parameters:  params,
-	}
-
-	smr, _, err := client.SpotMarketRequests.Create(smrc, d.Get("project_id").(string))
-	if err != nil {
-		return err
-	}
-
-	d.SetId(smr.ID)
-
-	if waitForDevices {
-		stateConf := &resource.StateChangeConf{
-			Pending:        []string{"not_done"},
-			Target:         []string{"done"},
-			Refresh:        resourceStateRefreshFunc(d, meta),
-			Timeout:        d.Timeout(schema.TimeoutCreate),
-			MinTimeout:     5 * time.Second,
-			Delay:          3 * time.Second, // Wait 10 secs before starting
-			NotFoundChecks: 600,             //Setting high number, to support long timeouts
-		}
-
-		_, err = stateConf.WaitForState()
-		if err != nil {
-			return err
-		}
-	}
-
-	return resourcePacketSpotMarketRequestRead(d, meta)
-}
-
-func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
-
-	smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
+	smr, _, err := client.SpotMarketRequests.Get(id, &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
 	if err != nil {
 		err = friendlyError(err)
 		if isNotFound(err) {
@@ -229,83 +41,7 @@ func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{
 	for i, d := range smr.Devices {
 		deviceIDs[i] = d.ID
 	}
-
-	facilityIDs := make([]string, len(smr.Facilities))
-	if len(smr.Facilities) > 0 {
-		for i, f := range smr.Facilities {
-			facilityIDs[i] = f.ID
-		}
-	}
-	d.Set("project_id", smr.Project.ID)
-
+	d.Set("device_ids", deviceIDs)
+	d.SetId("id")
 	return nil
-}
-
-func resourcePacketSpotMarketRequestDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
-	var waitForDevices bool
-
-	if val, ok := d.GetOk("wait_for_devices"); ok {
-		waitForDevices = val.(bool)
-	}
-	if waitForDevices {
-		smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
-		if err != nil {
-			return nil
-		}
-
-		stateConf := &resource.StateChangeConf{
-			Pending:        []string{"not_done"},
-			Target:         []string{"done"},
-			Refresh:        resourceStateRefreshFunc(d, meta),
-			Timeout:        d.Timeout(schema.TimeoutDelete),
-			MinTimeout:     5 * time.Second,
-			Delay:          3 * time.Second, // Wait 10 secs before starting
-			NotFoundChecks: 600,             //Setting high number, to support long timeouts
-		}
-
-		_, err = stateConf.WaitForState()
-		if err != nil {
-			return err
-		}
-
-		for _, d := range smr.Devices {
-			_, err := client.Devices.Delete(d.ID)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	_, err := client.SpotMarketRequests.Delete(d.Id(), true)
-	if err != nil {
-		return nil
-	}
-	return nil
-}
-
-func resourceStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		client := meta.(*packngo.Client)
-		smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
-
-		if err != nil {
-			return nil, "", err
-
-		}
-		var finished bool
-
-		for _, d := range smr.Devices {
-
-			dev, _, _ := client.Devices.Get(d.ID, nil)
-			if dev.State != "active" {
-				break
-			} else {
-				finished = true
-			}
-		}
-		if finished {
-			return smr, "done", nil
-		}
-		return nil, "not_done", nil
-	}
 }

--- a/packet/datasource_packet_spot_market_request.go
+++ b/packet/datasource_packet_spot_market_request.go
@@ -1,6 +1,8 @@
 package packet
 
 import (
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/packethost/packngo"
 )
@@ -42,6 +44,6 @@ func dataSourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interfac
 		deviceIDs[i] = d.ID
 	}
 	d.Set("device_ids", deviceIDs)
-	d.SetId("id")
+	d.SetId(id + strings.Join(deviceIDs, "-"))
 	return nil
 }

--- a/packet/datasource_packet_spot_market_request.go
+++ b/packet/datasource_packet_spot_market_request.go
@@ -3,7 +3,7 @@ package packet
 import (
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/packethost/packngo"
 )
 

--- a/packet/datasource_packet_spot_market_request_test.go
+++ b/packet/datasource_packet_spot_market_request_test.go
@@ -1,0 +1,60 @@
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/packethost/packngo"
+)
+
+func TestAccDataSourcePacketSpotMarketRequest_Basic(t *testing.T) {
+	projectName := fmt.Sprintf("ds-device-%s", acctest.RandString(10))
+	var key packngo.SpotMarketRequest
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketSpotMarketRequestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePacketSpotMarketRequestConfig_Basic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPacketSpotMarketRequestExists("packet_spot_market_request.req", &key),
+					resource.TestCheckResourceAttr(
+						"data.packet_spot_market_request.dreq", "device_ids.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourcePacketSpotMarketRequestConfig_Basic(projSuffix string) string {
+	return fmt.Sprintf(`
+
+resource "packet_project" "test" {
+  name = "tfacc-spot_market_request-%s"
+}
+
+resource "packet_spot_market_request" "req" {
+  project_id    = "${packet_project.test.id}"
+  max_bid_price = 0.2
+  facilities    = ["sjc1"]
+  devices_min   = 2
+  devices_max   = 2
+  wait_for_devices = true
+
+  instance_parameters {
+    hostname         = "testspot"
+    billing_cycle    = "hourly"
+    operating_system = "ubuntu_16_04"
+    plan             = "t1.small.x86"
+  }
+}
+
+data "packet_spot_market_request" "dreq" {
+  request_id = packet_spot_market_request.req.id
+}
+`, projSuffix)
+}

--- a/packet/datasource_packet_spot_market_request_test.go
+++ b/packet/datasource_packet_spot_market_request_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/packethost/packngo"
 )
 

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -27,6 +27,7 @@ func Provider() terraform.ResourceProvider {
 			"packet_spot_market_price":   dataSourceSpotMarketPrice(),
 			"packet_device":              dataSourcePacketDevice(),
 			"packet_project":             dataSourcePacketProject(),
+			"packet_spot_market_request": dataSourcePacketSpotMarketRequest(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/device.html.markdown
+++ b/website/docs/d/device.html.markdown
@@ -18,7 +18,7 @@ Provides a Packet device datasource.
 ## Example Usage
 
 ```hcl
-# Fetch a device data and show it's ID
+# Fetch a device data by hostname and show it's ID
 
 data "packet_device" "test" {
   project_id       = "${local.project_id}"
@@ -31,12 +31,25 @@ output "id" {
 
 ```
 
+```hcl
+# Fetch a device data by ID and show its public IPv4
+
+data "packet_device" "test" {
+
+output "ipv4" {
+  value = "${data.packet_device.test.access_public_ipv4}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `hostname` - (Required) The device name
-* `project_id` - (Required) The id of the project in which the devices exists
+* `hostname` - The device name
+* `project_id` - The id of the project in which the devices exists
+* `device_id` - Device ID
+
+User can lookup devices either by `device_id` or `project_id` and `hostname`.
 
 ## Attributes Reference
 

--- a/website/docs/d/spot_market_request.html.markdown
+++ b/website/docs/d/spot_market_request.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "packet"
+page_title: "Packet: packet_spot_market_request"
+sidebar_current: "docs-packet-datasource-spot-market-request"
+description: |-
+  Provides a datasource for existing Spot Market Requests in the Packet host.
+---
+
+# packet_spot_market_request
+
+Provides a Packet spot_market_request datasource. The datasource will contain list of device IDs created by referenced Spot Market Request.
+
+
+
+## Example Usage
+
+```hcl
+# Create a Spot Market Request, and print public IPv4 of the created devices, if any.
+
+resource "packet_spot_market_request" "req" {
+  project_id    = "${local.project_id}"
+  max_bid_price = 0.1
+  facilities    = ["ewr1"]
+  devices_min   = 2
+  devices_max   = 2
+  wait_for_devices = true
+
+  instance_parameters {
+    hostname         = "testspot"
+    billing_cycle    = "hourly"
+    operating_system = "ubuntu_16_04"
+    plan             = "t1.small.x86"
+  }
+}
+
+data "packet_spot_market_request" "dreq" {
+  request_id = packet_spot_market_request.req.id
+}
+
+output "ids" {
+  value = data.packet_spot_market_request.dreq.device_ids
+}
+
+data "packet_device" "devs" {
+    count = length(data.packet_spot_market_request.dreq.device_ids)
+    device_id = data.packet_spot_market_request.dreq.device_ids[count.index]
+}
+
+output "ips" {
+    value = [for d in data.packet_device.devs: d.access_public_ipv4]
+}
+
+```
+
+With the code as `main.tf`, first create the spot market request:
+
+```
+$ terraform apply -target packet_spot_market_request.req
+```
+
+When the terraform run ends, run a full apply, and the IPv4 addresses will be printed:
+
+```
+$ terraform apply
+
+[...]
+ 
+ips = [
+  "947.85.199.231",
+  "947.85.194.181",
+]
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `request_id` - (Required) The id of the Spot Market Request
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `device_ids` - List of IDs of devices spawned by the referenced Spot Market Request

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -31,6 +31,9 @@
             <li<%= sidebar_current("docs-packet-datasource-spot-market-price") %>>
              <a href="/docs/providers/packet/d/spot_market_price.html">packet_spot_market_price</a>
            </li>
+            <li<%= sidebar_current("docs-packet-datasource-spot-market-request") %>>
+             <a href="/docs/providers/packet/d/spot_market_request.html">packet_spot_market_request</a>
+           </li>
          </ul>
        </li>
 


### PR DESCRIPTION
This PR adds a datasource for spot market request, so that users can check the device IDs of spawned devices.

 fixes #107.