### PR TITLE
Add description attr to packet_reserved_ip_block, tests and doc

### DIFF
--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -75,6 +75,11 @@ func resourcePacketReservedIPBlock() *schema.Resource {
 		Optional: true,
 		ForceNew: true,
 	}
+	reservedBlockSchema["description"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+	}
 	reservedBlockSchema["quantity"] = &schema.Schema{
 		Type:     schema.TypeInt,
 		Required: true,
@@ -121,6 +126,10 @@ func resourcePacketReservedIPBlockCreate(d *schema.ResourceData, meta interface{
 	fs := f.(string)
 	if typ == "public_ipv4" {
 		req.Facility = &fs
+	}
+	desc, ok := d.GetOk("description")
+	if ok {
+		req.Description = desc.(string)
 	}
 
 	projectID := d.Get("project_id").(string)
@@ -210,6 +219,9 @@ func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error reading IP address block with ID %s: %s", id, err)
 	}
 	err = loadBlock(d, reservedBlock)
+	if (reservedBlock.Description != nil) && (*(reservedBlock.Description) != "") {
+		d.Set("description", *(reservedBlock.Description))
+	}
 	d.Set("global", getGlobalBool(reservedBlock))
 	if err != nil {
 		return err

--- a/packet/resource_packet_reserved_ip_block_test.go
+++ b/packet/resource_packet_reserved_ip_block_test.go
@@ -19,6 +19,7 @@ resource "packet_project" "foobar" {
 resource "packet_reserved_ip_block" "test" {
     project_id = "${packet_project.foobar.id}"
     type     = "global_ipv4"
+	description = "testdesc"
 	quantity = 1
 }`, name)
 }
@@ -30,10 +31,10 @@ resource "packet_project" "foobar" {
 }
 
 resource "packet_reserved_ip_block" "test" {
-    project_id = "${packet_project.foobar.id}"
-    facility = "ewr1"
-    type     = "public_ipv4"
-	quantity = 2
+    project_id  = "${packet_project.foobar.id}"
+    facility    = "ewr1"
+    type        = "public_ipv4"
+	quantity    = 2
 }`, name)
 }
 
@@ -51,6 +52,8 @@ func TestAccPacketReservedIPBlock_Global(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"packet_reserved_ip_block.test", "quantity", "1"),
+					resource.TestCheckResourceAttr(
+						"packet_reserved_ip_block.test", "description", "testdesc"),
 					resource.TestCheckResourceAttr(
 						"packet_reserved_ip_block.test", "type", "global_ipv4"),
 					resource.TestCheckResourceAttr(

--- a/website/docs/r/reserved_ip_block.html.markdown
+++ b/website/docs/r/reserved_ip_block.html.markdown
@@ -50,6 +50,7 @@ The following arguments are supported:
 * `quantity` - (Required) The number of allocated /32 addresses, a power of 2
 * `type` - (Optional) Either "global_ipv4" or "public_ipv4", defaults to "public_ipv4" for backward compatibility
 * `facility` - (Optional) Facility where to allocate the public IP address block, makes sense only for type==public_ipv4, must be empty for type==global_ipv4
+* `description` - (Optional) Arbitrary description
 
 
 ## Attributes Reference


### PR DESCRIPTION
This adds `description` attr to `packet_reserved_ip_block`, and fixes #163 