### PR TITLE
Add ip_block_ranges datasource, doc

### DIFF
--- a/packet/datasource_packet_ip_block_ranges.go
+++ b/packet/datasource_packet_ip_block_ranges.go
@@ -1,0 +1,104 @@
+package packet
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/packethost/packngo"
+)
+
+func dataSourcePacketIPBlockRanges() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePacketIPBlockRangesRead,
+
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"facility": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ipv4": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"global_ipv4": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"private_ipv4": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"ipv6": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func faclityMatch(ref, ipFacility string) bool {
+	if ref == "" {
+		return true
+	}
+	if ref == ipFacility {
+		return true
+	}
+	return false
+}
+
+func dataSourcePacketIPBlockRangesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	projectID := d.Get("project_id").(string)
+	ips, _, err := client.ProjectIPs.List(projectID)
+	if err != nil {
+		return err
+	}
+
+	facility := d.Get("facility").(string)
+
+	publicIPv4s := []string{}
+	globalIPv4s := []string{}
+	privateIPv4s := []string{}
+	theIPv6s := []string{}
+	var targetSlice *[]string
+
+	for _, ip := range ips {
+		targetSlice = nil
+		cnStr := fmt.Sprintf("%s/%d", ip.Network, ip.CIDR)
+		if ip.AddressFamily == 4 {
+			if ip.Public {
+				if getGlobalBool(&ip) {
+					globalIPv4s = append(globalIPv4s, cnStr)
+				} else {
+					targetSlice = &publicIPv4s
+				}
+			} else {
+				targetSlice = &privateIPv4s
+			}
+		} else {
+			targetSlice = &theIPv6s
+		}
+		if targetSlice != nil && faclityMatch(facility, ip.Facility.Code) {
+			*targetSlice = append(*targetSlice, cnStr)
+		}
+	}
+
+	d.Set("public_ipv4", publicIPv4s)
+	d.Set("global_ipv4", globalIPv4s)
+	d.Set("private_ipv4", privateIPv4s)
+	d.Set("ipv6", theIPv6s)
+	if facility != "" {
+		facility = "-" + facility
+	}
+	d.SetId(projectID + facility + "-IPs")
+	return nil
+
+}

--- a/packet/datasource_packet_ip_block_ranges_test.go
+++ b/packet/datasource_packet_ip_block_ranges_test.go
@@ -1,0 +1,64 @@
+package packet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPacketIPBlockRanges_Basic(t *testing.T) {
+
+	rs := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testIPBlockRangesConfig_Basic(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.packet_ip_block_ranges.test", "ipv6.0"),
+					resource.TestCheckResourceAttrPair(
+						"packet_ip_attachment.test", "device_id",
+						"packet_device.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "packet_ip_attachment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testIPBlockRangesConfig_Basic(name string) string {
+	return fmt.Sprintf(`
+
+resource "packet_project" "test" {
+    name = "tfacc-precreated_ip_block-%s"
+}
+
+resource "packet_device" "test" {
+  hostname         = "tftest"
+  plan             = "t1.small.x86"
+  facilities       = ["ewr1"]
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = packet_project.test.id
+}
+
+data "packet_ip_block_ranges" "test" {
+    facility         = "ewr1"
+    project_id       = packet_device.test.project_id
+}
+
+resource "packet_ip_attachment" "test" {
+    device_id = packet_device.test.id
+    cidr_notation = cidrsubnet(data.packet_ip_block_ranges.test.ipv6.0, 8,2)
+}
+`, name)
+}

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -21,6 +21,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"packet_ip_block_ranges":     dataSourcePacketIPBlockRanges(),
 			"packet_precreated_ip_block": dataSourcePacketPreCreatedIPBlock(),
 			"packet_operating_system":    dataSourceOperatingSystem(),
 			"packet_spot_market_price":   dataSourceSpotMarketPrice(),

--- a/website/docs/d/ip_block_ranges.html.markdown
+++ b/website/docs/d/ip_block_ranges.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "packet"
+page_title: "Packet: ip_block_ranges"
+sidebar_current: "docs-packet-datasource-ip-block-ranges"
+description: |-
+  List IP address ranges allocated to a project
+---
+
+# packet\_ip\_block\_ranges
+
+Use this datasource to get CIDR expressions for allocated IP blocks of all the types in a project, optionally filtered by facility.
+
+There are four types of IP blocks in Packet: global IPv4, public IPv4, private IPv4 and IPv6. Both global and public IPv4 are routable from the Internet. Public IPv4 block is allocated in a facility, and addresses from it can only be assigned to devices in that facility. Addresses from Global IPv4 block can be assigned to a device in any facility.
+
+The datasource has 4 list attributes: `global_ipv4`, `public_ipv4`, `private_ipv4` and `ipv6`, each listing CIDR notation (`<network>/<mask>`) of respective blocks from the project.
+
+## Example Usage
+
+```hcl
+
+# List CIDR expressions of all the allocated IP block in you project.
+
+# Declare your project ID
+locals {
+  project_id = "<UUID_of_your_project>"
+}
+
+data "packet_ip_block_ranges" "test" {
+  project_id       = local.project_id
+}
+
+output "out" {
+  value = data.packet_ip_block_ranges.test
+}
+
+```
+
+## Argument Reference
+
+ * `project_id` - (Required) ID of the project from which to list the blocks. 
+ * `facility` - (Optional) Facility code filtering the IP blocks. Global IPv4 blcoks will be listed anyway. If you omit this, all the block from the project will be listed.
+
+## Attributes Reference
+
+ * `global_ipv4` - list of CIDR expressions for Global IPv4 blocks in the project
+ * `public_ipv4` - list of CIDR expressions for Public IPv4 blocks in the project
+ * `private_ipv4` - list of CIDR expressions for Private IPv4 blocks in the project
+ * `ipv6` - list of CIDR expressions for IPv6 blocks in the project

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -16,6 +16,9 @@
            <li<%= sidebar_current("docs-packet-datasource-device") %>>
              <a href="/docs/providers/packet/d/device.html">packet_device</a>
            </li>
+           <li<%= sidebar_current("docs-packet-datasource-ip-block-ranges") %>>
+             <a href="/docs/providers/packet/d/ip_block_ranges.html">packet_ip_block_ranges</a>
+           </li>
            <li<%= sidebar_current("docs-packet-datasource-precreated-ip-block") %>>
              <a href="/docs/providers/packet/d/precreated_ip_block.html">packet_precreated_ip_block</a>
            </li>


### PR DESCRIPTION
The PR adds a datasource for listing CIDR expressions for IP block allocated for a project. I had a request from Packet to do this.