### PR TITLE
Remove incorrect statemets wrt project ssh keys

### DIFF
--- a/website/docs/r/project_ssh_key.html.markdown
+++ b/website/docs/r/project_ssh_key.html.markdown
@@ -8,9 +8,8 @@ description: |-
 
 # packet_project_ssh_key
 
-Provides a Packet project SSH key resource to manage project-specific SSH keys. On contrary to user SSH keys, project SSH keys are used to exclusively populate `authorized_keys` in new devices.
-
-If you supply a list of project SSH keys when creating a new device, only the listed keys are used; user SSH keys are ignored.
+Provides a Packet project SSH key resource to manage project-specific SSH keys.
+Project SSH keys will only be populated onto servers that belong to that project, in contrast to User SSH Keys.
 
 ## Example Usage
 


### PR DESCRIPTION
I believe at some point the documented behavior matched was we were doing at packet, but that was deemed that we were doing it wrong so was changed. Both the portal and kb pages document an additive behavior.