### PR TITLE
Enable packet_ssh_key resource import

### DIFF
--- a/packet/resource_packet_ssh_key.go
+++ b/packet/resource_packet_ssh_key.go
@@ -41,6 +41,9 @@ func resourcePacketSSHKey() *schema.Resource {
 		Read:   resourcePacketSSHKeyRead,
 		Update: resourcePacketSSHKeyUpdate,
 		Delete: resourcePacketSSHKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: packetSSHKeyCommonFields(),
 	}

--- a/packet/resource_packet_ssh_key_test.go
+++ b/packet/resource_packet_ssh_key_test.go
@@ -74,6 +74,28 @@ func TestAccPacketSSHKey_Update(t *testing.T) {
 	})
 }
 
+func TestAccPacketSSHKey_importBasic(t *testing.T) {
+	sshKey, _, err := acctest.RandSSHKeyPair("")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPacketSSHKeyConfig_basic(acctest.RandInt(), sshKey),
+			},
+			{
+				ResourceName:      "packet_ssh_key.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckPacketSSHKeyDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*packngo.Client)
 


### PR DESCRIPTION
This PR enables packet_ssh_key resource import and adds the acceptance test for it.