### PR TITLE
Enable packet_organization resource import & acc test

### DIFF
--- a/packet/resource_packet_organization.go
+++ b/packet/resource_packet_organization.go
@@ -11,6 +11,9 @@ func resourcePacketOrganization() *schema.Resource {
 		Read:   resourcePacketOrganizationRead,
 		Update: resourcePacketOrganizationUpdate,
 		Delete: resourcePacketOrganizationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -32,6 +32,24 @@ func TestAccOrgCreate(t *testing.T) {
 	})
 }
 
+func TestAccOrg_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketOrgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPacketOrgConfigBasic,
+			},
+			{
+				ResourceName:      "packet_organization.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckPacketOrgDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*packngo.Client)
 


### PR DESCRIPTION
Enables packet_organization resource import and adds the acceptance test for it. Related to #51 

Organization import worked when I tested it manually. The import test failed on my local environment since I have no permission to create a new organization.

```
=== RUN   TestAccOrg_importBasic
2019/10/28 22:35:30 [DEBUG] POST https://api.packet.net/organizations
--- FAIL: TestAccOrg_importBasic (3.01s)
    testing.go:569: Step 0 error: errors during apply:

        Error: Sorry! You have reached the maximum number of organizations you can create (1). The Packet team has been notified of this and will be in touch shortly. If this is urgent, please email help@packet.net to request additional deployment capacity.
```