### PR TITLE
change org name in org datasource test

### DIFF
--- a/packet/datasource_packet_organization_test.go
+++ b/packet/datasource_packet_organization_test.go
@@ -20,13 +20,12 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 				Config: testAccCheckPacketOrgDataSourceConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
-					testAccCheckPacketOrgAttributes(&org),
 					resource.TestCheckResourceAttr(
-						"packet_organization.test", "name", "foobar2"),
+						"packet_organization.test", "name", "TF Datasource test Org"),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "description", "quux"),
 					resource.TestCheckResourceAttr(
-						"data.packet_organization.test", "name", "foobar2"),
+						"data.packet_organization.test", "name", "TF Datasource test Org"),
 					resource.TestCheckResourceAttrPair(
 						"data.packet_organization.test2", "id", "packet_organization.test", "id"),
 				),
@@ -37,7 +36,7 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 
 var testAccCheckPacketOrgDataSourceConfigBasic = fmt.Sprintf(`
 resource "packet_organization" "test" {
-		name = "foobar2"
+		name = "TF Datasource test Org"
 		description = "quux"
 }
 
@@ -46,7 +45,7 @@ data "packet_organization" "test" {
 }
 
 data "packet_organization" "test2" {
-    name = packet_organization.test.name
+    name = "${packet_organization.test.name}"
 }
 
 `)

--- a/packet/datasource_packet_organization_test.go
+++ b/packet/datasource_packet_organization_test.go
@@ -22,11 +22,11 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
 					testAccCheckPacketOrgAttributes(&org),
 					resource.TestCheckResourceAttr(
-						"packet_organization.test", "name", "foobar"),
+						"packet_organization.test", "name", "foobar2"),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "description", "quux"),
 					resource.TestCheckResourceAttr(
-						"data.packet_organization.test", "name", "foobar"),
+						"data.packet_organization.test", "name", "foobar2"),
 					resource.TestCheckResourceAttrPair(
 						"data.packet_organization.test2", "id", "packet_organization.test", "id"),
 				),
@@ -37,7 +37,7 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 
 var testAccCheckPacketOrgDataSourceConfigBasic = fmt.Sprintf(`
 resource "packet_organization" "test" {
-		name = "foobar"
+		name = "foobar2"
 		description = "quux"
 }
 

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -21,7 +21,6 @@ func TestAccOrgCreate(t *testing.T) {
 				Config: testAccCheckPacketOrgConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
-					testAccCheckPacketOrgAttributes(&org),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "name", "foobar"),
 					resource.TestCheckResourceAttr(
@@ -63,15 +62,6 @@ func testAccCheckPacketOrgDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckPacketOrgAttributes(org *packngo.Organization) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if org.Name != "foobar" {
-			return fmt.Errorf("Bad name: %s", org.Name)
-		}
-		return nil
-	}
 }
 
 func testAccCheckPacketOrgExists(n string, org *packngo.Organization) resource.TestCheckFunc {


### PR DESCRIPTION
This is to fix Acceptance test for organization datasource. The Teamcity runs were failing with

```
------- Stdout: -------
=== RUN   TestAccOrgDataSource_Basic
--- FAIL: TestAccOrgDataSource_Basic (5.70s)
    testing.go:569: Step 0 error: errors during apply:
        
        Error: too many organizations found with name foobar (found 2, expected 1)
        
          on /opt/teamcity-agent/temp/buildTmp/tf-test103161711/main.tf line 11:
          (source code not available)
        
        
    testing.go:630: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: too many organizations found with name foobar (found 2, expected 1)
        
        State: <nil>
```

..this should fix the test fail