### PR TITLE
Add import of project SSH keys

### DIFF
--- a/packet/resource_packet_project_ssh_key.go
+++ b/packet/resource_packet_project_ssh_key.go
@@ -2,7 +2,6 @@ package packet
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func resourcePacketProjectSSHKey() *schema.Resource {
@@ -14,41 +13,12 @@ func resourcePacketProjectSSHKey() *schema.Resource {
 	}
 	return &schema.Resource{
 		Create: resourcePacketSSHKeyCreate,
-		Read:   resourcePacketProjectSSHKeyRead,
+		Read:   resourcePacketSSHKeyRead,
 		Update: resourcePacketSSHKeyUpdate,
 		Delete: resourcePacketSSHKeyDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: pkeySchema,
 	}
-}
-
-func resourcePacketProjectSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
-	projectID := d.Get("project_id").(string)
-	projectKeys, _, err := client.SSHKeys.ProjectList(projectID)
-	if err != nil {
-		err = friendlyError(err)
-		if isNotFound(err) {
-			d.SetId("")
-			return nil
-		}
-
-		return err
-	}
-
-	keyFound := false
-	for _, k := range projectKeys {
-		if k.ID == d.Id() {
-			keyFound = true
-			d.Set("name", k.Label)
-			d.Set("public_key", k.Key)
-			d.Set("fingerprint", k.FingerPrint)
-			d.Set("created", k.Created)
-			d.Set("updated", k.Updated)
-		}
-	}
-	if !keyFound {
-		d.SetId("")
-	}
-	return nil
 }

--- a/packet/resource_packet_ssh_key.go
+++ b/packet/resource_packet_ssh_key.go
@@ -74,11 +74,6 @@ func resourcePacketSSHKeyCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.SetId(key.ID)
-	/*
-		if isProjectKey {
-			return resourcePacketProjectSSHKeyRead(d, meta)
-		}
-	*/
 
 	return resourcePacketSSHKeyRead(d, meta)
 }

--- a/packet/resource_packet_ssh_key.go
+++ b/packet/resource_packet_ssh_key.go
@@ -1,6 +1,8 @@
 package packet
 
 import (
+	"path"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/packethost/packngo"
 )
@@ -28,6 +30,10 @@ func packetSSHKeyCommonFields() map[string]*schema.Schema {
 		},
 
 		"updated": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"owner_id": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
@@ -68,9 +74,11 @@ func resourcePacketSSHKeyCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.SetId(key.ID)
-	if isProjectKey {
-		return resourcePacketProjectSSHKeyRead(d, meta)
-	}
+	/*
+		if isProjectKey {
+			return resourcePacketProjectSSHKeyRead(d, meta)
+		}
+	*/
 
 	return resourcePacketSSHKeyRead(d, meta)
 }
@@ -92,12 +100,19 @@ func resourcePacketSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	ownerID := path.Base(key.Owner.Href)
+
 	d.Set("id", key.ID)
 	d.Set("name", key.Label)
 	d.Set("public_key", key.Key)
 	d.Set("fingerprint", key.FingerPrint)
+	d.Set("owner_id", ownerID)
 	d.Set("created", key.Created)
 	d.Set("updated", key.Updated)
+
+	if key.Owner.Href[:10] == "/projects/" {
+		d.Set("project_id", ownerID)
+	}
 
 	return nil
 }

--- a/packet/resource_packet_ssh_key_test.go
+++ b/packet/resource_packet_ssh_key_test.go
@@ -31,6 +31,33 @@ func TestAccPacketSSHKey_Basic(t *testing.T) {
 						"packet_ssh_key.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"packet_ssh_key.foobar", "public_key", publicKeyMaterial),
+					resource.TestCheckResourceAttrSet(
+						"packet_ssh_key.foobar", "owner_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPacketSSHKey_ProjectBasic(t *testing.T) {
+	rInt := acctest.RandInt()
+	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPacketSSHKeyConfig_projectBasic(rInt, publicKeyMaterial),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"packet_project.test", "id",
+						"packet_project_ssh_key.foobar", "project_id",
+					),
 				),
 			},
 		},
@@ -69,6 +96,28 @@ func TestAccPacketSSHKey_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"packet_ssh_key.foobar", "public_key", publicKeyMaterial),
 				),
+			},
+		},
+	})
+}
+
+func TestAccPacketSSHKey_projectImportBasic(t *testing.T) {
+	sshKey, _, err := acctest.RandSSHKeyPair("")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPacketSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckPacketSSHKeyConfig_projectBasic(acctest.RandInt(), sshKey),
+			},
+			{
+				ResourceName:      "packet_project_ssh_key.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -144,4 +193,18 @@ resource "packet_ssh_key" "foobar" {
     name = "foobar-%d"
     public_key = "%s"
 }`, rInt, publicSshKey)
+}
+
+func testAccCheckPacketSSHKeyConfig_projectBasic(rInt int, publicSshKey string) string {
+	return fmt.Sprintf(`
+
+resource "packet_project" "test" {
+    name = "test-%d"
+}
+
+resource "packet_project_ssh_key" "foobar" {
+    name = "foobar-%d"
+    public_key = "%s"
+	project_id = packet_project.test.id
+}`, rInt, rInt, publicSshKey)
 }

--- a/website/docs/r/project_ssh_key.html.markdown
+++ b/website/docs/r/project_ssh_key.html.markdown
@@ -52,6 +52,7 @@ The following attributes are exported:
 * `name` - The name of the SSH key
 * `public_key` - The text of the public key
 * `project_id` - The ID of parent project
+* `owner_id` - The ID of parent project (same as project_id)
 * `fingerprint` - The fingerprint of the SSH key
 * `created` - The timestamp for when the SSH key was created
 * `updated` - The timestamp for the last time the SSH key was updated

--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -51,5 +51,6 @@ The following attributes are exported:
 * `name` - The name of the SSH key
 * `public_key` - The text of the public key
 * `fingerprint` - The fingerprint of the SSH key
+* `owner_id` - The UUID of the Packet API User who owns this key
 * `created` - The timestamp for when the SSH key was created
 * `updated` - The timestamp for the last time the SSH key was updated


### PR DESCRIPTION
This PR simplifies handling of the SSH key resources. It also implements import of project_ssh_key resources. 

#51, update ssh_keys checkbox when this is merged.