### PR TITLE
Device creation rate limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/packethost/packngo v0.2.1-0.20191030123207-e34c34ef3c41
 	github.com/vmihailenco/msgpack v4.0.1+incompatible // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/packet/datasource_packet_device.go
+++ b/packet/datasource_packet_device.go
@@ -174,7 +174,8 @@ func dataSourcePacketDevice() *schema.Resource {
 }
 
 func dataSourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	hostnameRaw, hostnameOK := d.GetOk("hostname")
 	projectIdRaw, projectIdOK := d.GetOk("project_id")

--- a/packet/datasource_packet_ip_block_ranges.go
+++ b/packet/datasource_packet_ip_block_ranges.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func dataSourcePacketIPBlockRanges() *schema.Resource {
@@ -55,7 +54,8 @@ func faclityMatch(ref, ipFacility string) bool {
 }
 
 func dataSourcePacketIPBlockRangesRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	projectID := d.Get("project_id").(string)
 	ips, _, err := client.ProjectIPs.List(projectID)
 	if err != nil {

--- a/packet/datasource_packet_operating_system.go
+++ b/packet/datasource_packet_operating_system.go
@@ -38,7 +38,8 @@ func dataSourceOperatingSystem() *schema.Resource {
 }
 
 func dataSourcePacketOperatingSystemRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	name, nameOK := d.GetOk("name")
 	distro, distroOK := d.GetOk("distro")

--- a/packet/datasource_packet_organization.go
+++ b/packet/datasource_packet_organization.go
@@ -70,7 +70,8 @@ func findOrgByName(os []packngo.Organization, name string) (*packngo.Organizatio
 }
 
 func dataSourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	nameRaw, nameOK := d.GetOk("name")
 	orgIdRaw, orgIdOK := d.GetOk("organization_id")
 

--- a/packet/datasource_packet_precreated_ip_block.go
+++ b/packet/datasource_packet_precreated_ip_block.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func dataSourcePacketPreCreatedIPBlock() *schema.Resource {
@@ -48,7 +47,8 @@ func dataSourcePacketPreCreatedIPBlock() *schema.Resource {
 }
 
 func dataSourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	projectID := d.Get("project_id").(string)
 	log.Println("[DEBUG] packet_precreated_ip_block - getting list of IPs in a project")
 	ips, _, err := client.ProjectIPs.List(projectID)

--- a/packet/datasource_packet_project.go
+++ b/packet/datasource_packet_project.go
@@ -91,7 +91,8 @@ func dataSourcePacketProject() *schema.Resource {
 }
 
 func dataSourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	nameRaw, nameOK := d.GetOk("name")
 	projectIdRaw, projectIdOK := d.GetOk("project_id")
 

--- a/packet/datasource_packet_spot_market_price.go
+++ b/packet/datasource_packet_spot_market_price.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/packethost/packngo"
 )
 
 func dataSourceSpotMarketPrice() *schema.Resource {
@@ -28,7 +27,8 @@ func dataSourceSpotMarketPrice() *schema.Resource {
 }
 
 func dataSourcePacketSpotMarketPriceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	facility := d.Get("facility").(string)
 	plan := d.Get("plan").(string)

--- a/packet/datasource_packet_spot_market_request.go
+++ b/packet/datasource_packet_spot_market_request.go
@@ -26,7 +26,8 @@ func dataSourcePacketSpotMarketRequest() *schema.Resource {
 	}
 }
 func dataSourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	id := d.Get("request_id").(string)
 
 	smr, _, err := client.SpotMarketRequests.Get(id, &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})

--- a/packet/datasource_packet_volume.go
+++ b/packet/datasource_packet_volume.go
@@ -102,7 +102,8 @@ func dataSourcePacketVolume() *schema.Resource {
 }
 
 func dataSourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	nameRaw, nameOK := d.GetOk("name")
 	projectIdRaw, projectIdOK := d.GetOk("project_id")

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -19,6 +19,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("PACKET_AUTH_TOKEN", nil),
 				Description: "The API auth key for API operations.",
 			},
+			"max_simultaneous_devices_create": {
+				Type:        schema.TypeInt,
+				Required:    false,
+				DefaultFunc: schema.EnvDefaultFunc("PACKET_MAX_SIMULTANEOUS_DEVICES_CREATE", 6),
+				Description: "Maximum number of devices to create simultaneously",
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"packet_ip_block_ranges":     dataSourcePacketIPBlockRanges(),
@@ -54,10 +60,9 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := Config{
-		AuthToken: d.Get("auth_token").(string),
-	}
-	return config.Client(), nil
+	authToken := d.Get("auth_token").(string)
+	maxDevicesCreate := d.Get("max_simultaneous_devices_create").(int)
+	return GetProviderConfig(authToken, maxDevicesCreate), nil
 }
 
 var resourceDefaultTimeouts = &schema.ResourceTimeout{

--- a/packet/provider.go
+++ b/packet/provider.go
@@ -22,6 +22,7 @@ func Provider() terraform.ResourceProvider {
 			"max_simultaneous_devices_create": {
 				Type:        schema.TypeInt,
 				Required:    false,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("PACKET_MAX_SIMULTANEOUS_DEVICES_CREATE", 6),
 				Description: "Maximum number of devices to create simultaneously",
 			},

--- a/packet/resource_packet_bgp_session.go
+++ b/packet/resource_packet_bgp_session.go
@@ -45,7 +45,8 @@ func resourcePacketBGPSession() *schema.Resource {
 }
 
 func resourcePacketBGPSessionCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	dID := d.Get("device_id").(string)
 	addressFamily := d.Get("address_family").(string)
 	defaultRoute := d.Get("default_route").(bool)
@@ -63,7 +64,8 @@ func resourcePacketBGPSessionCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourcePacketBGPSessionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	bgpSession, _, err := client.BGPSessions.Get(d.Id(),
 		&packngo.GetOptions{Includes: []string{"device"}})
 	if err != nil {
@@ -89,7 +91,8 @@ func resourcePacketBGPSessionRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourcePacketBGPSessionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	_, err := client.BGPSessions.Delete(d.Id())
 	if err != nil {
 		return err

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/packethost/packngo"
 )
 
 func TestAccPacketBGPSession_Basic(t *testing.T) {
@@ -38,7 +37,8 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 }
 
 func testAccCheckPacketBGPSessionDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_bgp_session" {

--- a/packet/resource_packet_connect.go
+++ b/packet/resource_packet_connect.go
@@ -74,7 +74,8 @@ func waitForConnectStatus(d *schema.ResourceData, target string, pending string,
 }
 
 func connectRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	return func() (interface{}, string, error) {
 		if err := resourcePacketConnectRead(d, meta); err != nil {
@@ -137,7 +138,8 @@ func resourcePacketConnectRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePacketConnectDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	pc, _, err := client.Connects.Deprovision(d.Id(), d.Get("project_id").(string), false)
 	if err != nil {

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -298,7 +298,8 @@ func resourcePacketDevice() *schema.Resource {
 }
 
 func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	var facs []string
 	f, ok := d.GetOk("facility")
@@ -485,7 +486,8 @@ func getNetworkInfo(ips []*packngo.IPAddressAssignment) NetworkInfo {
 }
 
 func resourcePacketDeviceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	device, _, err := client.Devices.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project"}})
 	if err != nil {
@@ -593,7 +595,8 @@ func getPorts(ps []packngo.Port) []map[string]interface{} {
 }
 
 func resourcePacketDeviceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	if d.HasChange("locked") {
 		var action func(string) (*packngo.Response, error)
@@ -662,7 +665,8 @@ func resourcePacketDeviceUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourcePacketDeviceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	resId, ok := d.GetOk("hardware_reservation_id")
 	if _, err := client.Devices.Delete(d.Id()); err != nil {
@@ -680,7 +684,8 @@ func resourcePacketDeviceDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func reservationProvisionableRefresh(id string, meta interface{}) resource.StateRefreshFunc {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	return func() (interface{}, string, error) {
 		r, _, err := client.HardwareReservations.Get(id, nil)
 		if err != nil {
@@ -719,7 +724,8 @@ func waitForDeviceAttribute(d *schema.ResourceData, targets []string, pending []
 }
 
 func newDeviceStateRefreshFunc(d *schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	return func() (interface{}, string, error) {
 		if err := resourcePacketDeviceRead(d, meta); err != nil {
@@ -740,7 +746,8 @@ func newDeviceStateRefreshFunc(d *schema.ResourceData, attribute string, meta in
 
 // powerOnAndWait Powers on the device and waits for it to be active.
 func powerOnAndWait(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	_, err := client.Devices.PowerOn(d.Id())
 	if err != nil {
 		return friendlyError(err)

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -293,7 +293,8 @@ func TestAccPacketDevice_IPXEConfigMissing(t *testing.T) {
 }
 
 func testAccCheckPacketDeviceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_device" {
@@ -329,7 +330,8 @@ func testAccCheckPacketDeviceExists(n string, device *packngo.Device) resource.T
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundDevice, _, err := client.Devices.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -330,8 +330,8 @@ func testAccCheckPacketDeviceExists(n string, device *packngo.Device) resource.T
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundDevice, _, err := client.Devices.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_ip_attachment.go
+++ b/packet/resource_packet_ip_attachment.go
@@ -34,7 +34,8 @@ func resourcePacketIPAttachment() *schema.Resource {
 }
 
 func resourcePacketIPAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	deviceID := d.Get("device_id").(string)
 	ipa := d.Get("cidr_notation").(string)
 
@@ -51,7 +52,8 @@ func resourcePacketIPAttachmentCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePacketIPAttachmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	assignment, _, err := client.DeviceIPs.Get(d.Id(), nil)
 	if err != nil {
 		err = friendlyError(err)
@@ -90,7 +92,8 @@ func resourcePacketIPAttachmentRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourcePacketIPAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	_, err := client.DeviceIPs.Unassign(d.Id())
 	if err != nil {

--- a/packet/resource_packet_ip_attachment_test.go
+++ b/packet/resource_packet_ip_attachment_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/packethost/packngo"
 )
 
 func TestAccPacketIPAttachment_Basic(t *testing.T) {
@@ -39,7 +38,8 @@ func TestAccPacketIPAttachment_Basic(t *testing.T) {
 }
 
 func testAccCheckPacketIPAttachmentDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_ip_attachment" {

--- a/packet/resource_packet_organization.go
+++ b/packet/resource_packet_organization.go
@@ -59,7 +59,8 @@ func resourcePacketOrganization() *schema.Resource {
 }
 
 func resourcePacketOrganizationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	createRequest := &packngo.OrganizationCreateRequest{
 		Name: d.Get("name").(string),
@@ -92,7 +93,8 @@ func resourcePacketOrganizationCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	key, _, err := client.Organizations.Get(d.Id(), nil)
 	if err != nil {
@@ -121,7 +123,8 @@ func resourcePacketOrganizationRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourcePacketOrganizationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	updateRequest := &packngo.OrganizationUpdateRequest{}
 
@@ -158,7 +161,8 @@ func resourcePacketOrganizationUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourcePacketOrganizationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	_, err := client.Organizations.Delete(d.Id())
 	if err != nil {

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -75,8 +75,8 @@ func testAccCheckPacketOrgExists(n string, org *packngo.Organization) resource.T
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundOrg, _, err := client.Organizations.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -50,7 +50,8 @@ func TestAccOrg_importBasic(t *testing.T) {
 }
 
 func testAccCheckPacketOrgDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_organization" {
@@ -74,7 +75,8 @@ func testAccCheckPacketOrgExists(n string, org *packngo.Organization) resource.T
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundOrg, _, err := client.Organizations.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_port_vlan_attachment.go
+++ b/packet/resource_packet_port_vlan_attachment.go
@@ -58,7 +58,8 @@ func resourcePacketPortVlanAttachment() *schema.Resource {
 }
 
 func resourcePacketPortVlanAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	deviceID := d.Get("device_id").(string)
 	pName := d.Get("port_name").(string)
 	vlanVNID := d.Get("vlan_vnid").(int)
@@ -139,7 +140,8 @@ func resourcePacketPortVlanAttachmentCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourcePacketPortVlanAttachmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	deviceID := d.Get("device_id").(string)
 	pName := d.Get("port_name").(string)
 	vlanVNID := d.Get("vlan_vnid").(int)
@@ -183,7 +185,8 @@ func resourcePacketPortVlanAttachmentRead(d *schema.ResourceData, meta interface
 }
 
 func resourcePacketPortVlanAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	if d.HasChange("native") {
 		native := d.Get("native").(bool)
 		portID := d.Get("port_id").(string)
@@ -205,7 +208,8 @@ func resourcePacketPortVlanAttachmentUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourcePacketPortVlanAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	pID := d.Get("port_id").(string)
 	vlanID := d.Get("vlan_id").(string)
 	native := d.Get("native").(bool)

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/packethost/packngo"
 )
 
 func testAccCheckPacketPortVlanAttachmentConfig_L2Bonded(name string) string {
@@ -261,7 +260,8 @@ func TestAccPacketPortVlanAttachment_HybridMultipleVlans(t *testing.T) {
 }
 
 func testAccCheckPacketPortVlanAttachmentDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	device_id := ""
 	vlan_id := ""

--- a/packet/resource_packet_project.go
+++ b/packet/resource_packet_project.go
@@ -113,7 +113,8 @@ func expandBGPConfig(d *schema.ResourceData) packngo.CreateBGPConfigRequest {
 }
 
 func resourcePacketProjectCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	createRequest := &packngo.ProjectCreateRequest{
 		Name:           d.Get("name").(string),
@@ -148,7 +149,8 @@ func resourcePacketProjectCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourcePacketProjectRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	proj, _, err := client.Projects.Get(d.Id(), nil)
 	if err != nil {
@@ -218,7 +220,8 @@ func flattenBGPConfig(l *packngo.BGPConfig) []map[string]interface{} {
 }
 
 func resourcePacketProjectUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	updateRequest := &packngo.ProjectUpdateRequest{}
 	if d.HasChange("name") {
 		pName := d.Get("name").(string)
@@ -269,7 +272,8 @@ func resourcePacketProjectUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourcePacketProjectDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	_, err := client.Projects.Delete(d.Id())
 	if err != nil {

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -72,7 +72,8 @@ func TestAccPacketProjectSSHKey_Basic(t *testing.T) {
 }
 
 func testAccCheckPacketProjectSSHKeyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_project_ssh_key" {

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -197,8 +197,8 @@ func testAccCheckPacketProjectExists(n string, project *packngo.Project) resourc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundProject, _, err := client.Projects.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -172,7 +172,8 @@ func TestAccPacketProject_BGPUpdate(t *testing.T) {
 }
 
 func testAccCheckPacketProjectDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_project" {
@@ -196,7 +197,8 @@ func testAccCheckPacketProjectExists(n string, project *packngo.Project) resourc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundProject, _, err := client.Projects.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -110,7 +110,8 @@ func resourcePacketReservedIPBlock() *schema.Resource {
 }
 
 func resourcePacketReservedIPBlockCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	quantity := d.Get("quantity").(int)
 	typ := d.Get("type").(string)
 
@@ -206,7 +207,8 @@ func loadBlock(d *schema.ResourceData, reservedBlock *packngo.IPAddressReservati
 }
 
 func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	id := d.Id()
 
 	reservedBlock, _, err := client.ProjectIPs.Get(id, nil)
@@ -231,7 +233,8 @@ func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourcePacketReservedIPBlockDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	id := d.Id()
 

--- a/packet/resource_packet_reserved_ip_block_test.go
+++ b/packet/resource_packet_reserved_ip_block_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/packethost/packngo"
 )
 
 func testAccCheckPacketReservedIPBlockConfig_Global(name string) string {
@@ -120,7 +119,8 @@ func TestAccPacketReservedIPBlock_importBasic(t *testing.T) {
 }
 
 func testAccCheckPacketReservedIPBlockDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_reserved_ip_block" {

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -289,8 +289,8 @@ func resourcePacketSpotMarketRequestDelete(d *schema.ResourceData, meta interfac
 
 func resourceStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-	providerConfig := meta.(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := meta.(*ProviderConfig)
+		client := providerConfig.Client
 		smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
 
 		if err != nil {

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -114,7 +114,8 @@ func resourcePacketSpotMarketRequest() *schema.Resource {
 }
 
 func resourcePacketSpotMarketRequestCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	var waitForDevices bool
 
 	facilitiesRaw := d.Get("facilities").([]interface{})
@@ -214,7 +215,8 @@ func resourcePacketSpotMarketRequestCreate(d *schema.ResourceData, meta interfac
 }
 
 func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
 	if err != nil {
@@ -243,7 +245,8 @@ func resourcePacketSpotMarketRequestRead(d *schema.ResourceData, meta interface{
 }
 
 func resourcePacketSpotMarketRequestDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	var waitForDevices bool
 
 	if val, ok := d.GetOk("wait_for_devices"); ok {
@@ -286,7 +289,8 @@ func resourcePacketSpotMarketRequestDelete(d *schema.ResourceData, meta interfac
 
 func resourceStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 		smr, _, err := client.SpotMarketRequests.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "devices", "facilities"}})
 
 		if err != nil {

--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -33,7 +33,8 @@ func TestAccPacketSpotMarketRequest_Basic(t *testing.T) {
 }
 
 func testAccCheckPacketSpotMarketRequestDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_spot_market_request" {
@@ -57,7 +58,8 @@ func testAccCheckPacketSpotMarketRequestExists(n string, key *packngo.SpotMarket
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundKey, _, err := client.SpotMarketRequests.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -58,8 +58,8 @@ func testAccCheckPacketSpotMarketRequestExists(n string, key *packngo.SpotMarket
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundKey, _, err := client.SpotMarketRequests.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_ssh_key.go
+++ b/packet/resource_packet_ssh_key.go
@@ -56,7 +56,8 @@ func resourcePacketSSHKey() *schema.Resource {
 }
 
 func resourcePacketSSHKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	createRequest := &packngo.SSHKeyCreateRequest{
 		Label: d.Get("name").(string),
@@ -79,7 +80,8 @@ func resourcePacketSSHKeyCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourcePacketSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	key, _, err := client.SSHKeys.Get(d.Id(), nil)
 	if err != nil {
@@ -113,7 +115,8 @@ func resourcePacketSSHKeyRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePacketSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	updateRequest := &packngo.SSHKeyUpdateRequest{}
 
@@ -136,7 +139,8 @@ func resourcePacketSSHKeyUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourcePacketSSHKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	_, err := client.SSHKeys.Delete(d.Id())
 	if err != nil {

--- a/packet/resource_packet_ssh_key_test.go
+++ b/packet/resource_packet_ssh_key_test.go
@@ -171,8 +171,8 @@ func testAccCheckPacketSSHKeyExists(n string, key *packngo.SSHKey) resource.Test
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundKey, _, err := client.SSHKeys.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_ssh_key_test.go
+++ b/packet/resource_packet_ssh_key_test.go
@@ -146,7 +146,8 @@ func TestAccPacketSSHKey_importBasic(t *testing.T) {
 }
 
 func testAccCheckPacketSSHKeyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_ssh_key" {
@@ -170,7 +171,8 @@ func testAccCheckPacketSSHKeyExists(n string, key *packngo.SSHKey) resource.Test
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundKey, _, err := client.SSHKeys.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_vlan.go
+++ b/packet/resource_packet_vlan.go
@@ -75,7 +75,8 @@ func resourcePacketVlanRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePacketVlanDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	_, err := client.ProjectVirtualNetworks.Delete(d.Id())
 	if err != nil {

--- a/packet/resource_packet_vlan.go
+++ b/packet/resource_packet_vlan.go
@@ -39,7 +39,8 @@ func resourcePacketVlan() *schema.Resource {
 }
 
 func resourcePacketVlanCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	c := providerConfig.Client
 	createRequest := &packngo.VirtualNetworkCreateRequest{
 		ProjectID:   d.Get("project_id").(string),
 		Description: d.Get("description").(string),
@@ -54,7 +55,8 @@ func resourcePacketVlanCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePacketVlanRead(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	c := providerConfig.Client
 
 	vlan, _, err := c.ProjectVirtualNetworks.Get(d.Id(),
 		&packngo.GetOptions{Includes: []string{"assigned_to"}})
@@ -76,9 +78,9 @@ func resourcePacketVlanRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourcePacketVlanDelete(d *schema.ResourceData, meta interface{}) error {
 	providerConfig := meta.(*ProviderConfig)
-	client := providerConfig.Client
+	c := providerConfig.Client
 
-	_, err := client.ProjectVirtualNetworks.Delete(d.Id())
+	_, err := c.ProjectVirtualNetworks.Delete(d.Id())
 	if err != nil {
 		return friendlyError(err)
 	}

--- a/packet/resource_packet_vlan_test.go
+++ b/packet/resource_packet_vlan_test.go
@@ -44,7 +44,8 @@ func testAccCheckPacketVlanExists(n string, vlan *packngo.VirtualNetwork) resour
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundVlan, _, err := client.ProjectVirtualNetworks.Get(rs.Primary.ID, nil)
 		if err != nil {
@@ -61,7 +62,8 @@ func testAccCheckPacketVlanExists(n string, vlan *packngo.VirtualNetwork) resour
 }
 
 func testAccCheckPacketVlanDestroyed(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_vlan" {

--- a/packet/resource_packet_vlan_test.go
+++ b/packet/resource_packet_vlan_test.go
@@ -44,8 +44,8 @@ func testAccCheckPacketVlanExists(n string, vlan *packngo.VirtualNetwork) resour
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundVlan, _, err := client.ProjectVirtualNetworks.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_volume.go
+++ b/packet/resource_packet_volume.go
@@ -116,7 +116,8 @@ func resourcePacketVolume() *schema.Resource {
 }
 
 func resourcePacketVolumeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	createRequest := &packngo.VolumeCreateRequest{
 		PlanID:     d.Get("plan").(string),
@@ -180,7 +181,8 @@ func waitForVolumeAttribute(d *schema.ResourceData, target string, pending []str
 }
 
 func newVolumeStateRefreshFunc(d *schema.ResourceData, attribute string, meta interface{}) resource.StateRefreshFunc {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	return func() (interface{}, string, error) {
 		if err := resourcePacketVolumeRead(d, meta); err != nil {
@@ -200,7 +202,8 @@ func newVolumeStateRefreshFunc(d *schema.ResourceData, attribute string, meta in
 }
 
 func resourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	volume, _, err := client.Volumes.Get(d.Id(), &packngo.GetOptions{Includes: []string{"project", "snapshot_policies", "facility"}})
 	if err != nil {
@@ -247,7 +250,8 @@ func resourcePacketVolumeRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePacketVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	if d.HasChange("locked") {
 		// the change is true => false, i.e. unlock
@@ -302,7 +306,8 @@ func resourcePacketVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourcePacketVolumeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 
 	if _, err := client.Volumes.Delete(d.Id()); err != nil {
 		return friendlyError(err)

--- a/packet/resource_packet_volume_attachment.go
+++ b/packet/resource_packet_volume_attachment.go
@@ -34,7 +34,8 @@ func resourcePacketVolumeAttachment() *schema.Resource {
 }
 
 func resourcePacketVolumeAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	dID := d.Get("device_id").(string)
 	vID := d.Get("volume_id").(string)
 	log.Printf("[DEBUG] Attaching Volume (%s) to Instance (%s)\n", vID, dID)
@@ -58,7 +59,8 @@ func resourcePacketVolumeAttachmentCreate(d *schema.ResourceData, meta interface
 }
 
 func resourcePacketVolumeAttachmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	va, _, err := client.VolumeAttachments.Get(d.Id(), nil)
 	if err != nil {
 		err = friendlyError(err)
@@ -74,7 +76,8 @@ func resourcePacketVolumeAttachmentRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourcePacketVolumeAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*packngo.Client)
+	providerConfig := meta.(*ProviderConfig)
+	client := providerConfig.Client
 	_, err := client.VolumeAttachments.Delete(d.Id())
 	if err != nil {
 		return err

--- a/packet/resource_packet_volume_attachment_test.go
+++ b/packet/resource_packet_volume_attachment_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/packethost/packngo"
 )
 
 func TestAccPacketVolumeAttachment_Basic(t *testing.T) {
@@ -39,7 +38,8 @@ func TestAccPacketVolumeAttachment_Basic(t *testing.T) {
 }
 
 func testAccCheckPacketVolumeAttachmentDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_volume_attachment" {

--- a/packet/resource_packet_volume_test.go
+++ b/packet/resource_packet_volume_test.go
@@ -104,7 +104,8 @@ func TestAccPacketVolume_Update(t *testing.T) {
 }
 
 func testAccCheckPacketVolumeDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "packet_volume" {
@@ -157,7 +158,8 @@ func testAccCheckPacketVolumeExists(n string, volume *packngo.Volume) resource.T
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		client := testAccProvider.Meta().(*packngo.Client)
+	providerConfig := testAccProvider.Meta().(*ProviderConfig)
+	client := providerConfig.Client
 
 		foundVolume, _, err := client.Volumes.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/packet/resource_packet_volume_test.go
+++ b/packet/resource_packet_volume_test.go
@@ -158,8 +158,8 @@ func testAccCheckPacketVolumeExists(n string, volume *packngo.Volume) resource.T
 			return fmt.Errorf("No Record ID is set")
 		}
 
-	providerConfig := testAccProvider.Meta().(*ProviderConfig)
-	client := providerConfig.Client
+		providerConfig := testAccProvider.Meta().(*ProviderConfig)
+		client := providerConfig.Client
 
 		foundVolume, _, err := client.Volumes.Get(rs.Primary.ID, nil)
 		if err != nil {

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,127 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -278,6 +278,8 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
+# golang.org/x/sync v0.0.0-20190423024810-112230192c58
+golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa
 golang.org/x/sys/unix
 golang.org/x/sys/cpu

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -59,3 +59,4 @@ The following arguments are supported:
 
 * `auth_token` - (Required) This is your Packet API Auth token. This can also be specified
   with the `PACKET_AUTH_TOKEN` shell environment variable.
+* `max_simultaneous_devices_create` (Optional) This is a max number of devices that can be created simultaneously by the provider. It defaults to 6. If you lower it, you will be less likely to hit Packet API rate limit, but the `terraform apply` run will take longer. If you increase it, Terraform run will be faster, but you might get HTTP errors from Packet API rate limit.


### PR DESCRIPTION
This PR is to limit simultaneous device creation. Packet API rate limits device resource creation, usually max 5-6 devices can be created at a time, beyond that, user will get an HTTP error.

I am aware that it's possible to control this by `-parallelism=6` in `terraform apply`, but the default of 10 is too high for Packet API at the moment. After brief discussion with Hashicorp engs in Hashicorp commiters Slack, I decided to put a semaphore to `resourcePacketDeviceCreate`, which will limit the number of simultaneous requests.

I think this will improve user experience. Not everyone is aware of `-parallelism=n`, and I think it's OK to be able to use TF without the knowledge of all the knobs and switches.

The value for the semaphore will be 6 by default, and can be set in provider config as `max_simultaneous_devices_create`, or envvar `PACKET_MAX_SIMULTANEOUS_DEVICES_CREATE`.

For review, please check the diffs for `provider.go`, `config.go` and `resource_packet_device.go`. Also, feel free to suggest different naming.