### PR TITLE
Add mutex guard to VLAN detachment

### DIFF
--- a/packet/resource_packet_port_vlan_attachment.go
+++ b/packet/resource_packet_port_vlan_attachment.go
@@ -216,6 +216,9 @@ func resourcePacketPortVlanAttachmentDelete(d *schema.ResourceData, meta interfa
 		}
 	}
 	par := &packngo.PortAssignRequest{PortID: pID, VirtualNetworkID: vlanID}
+	lockId := "vlan-detachment-" + pID
+	packetMutexKV.Lock(lockId)
+	defer packetMutexKV.Unlock(lockId)
 	portPtr, _, err := client.DevicePorts.Unassign(par)
 	if err != nil {
 		return err


### PR DESCRIPTION
In Packet API, only one VLAN can be detached at a time. This PR adds a mutex guard around the detachment API call.