### PR TITLE
fix acceptance tests for Layer 2 networking (ports and VLANS)

### DIFF
--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -21,7 +21,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facilities       = ["dfw2"]
+  facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -29,14 +29,14 @@ resource "packet_device" "test" {
 }
 
 resource "packet_vlan" "test1" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN 1"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 
 resource "packet_vlan" "test2" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN 2"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -89,7 +89,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facilities       = ["dfw2"]
+  facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -97,14 +97,14 @@ resource "packet_device" "test" {
 }
 
 resource "packet_vlan" "test1" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN 1"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 
 resource "packet_vlan" "test2" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN 2"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -305,7 +305,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facilities       = ["dfw2"]
+  facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -313,14 +313,14 @@ resource "packet_device" "test" {
 }
 
 resource "packet_vlan" "test1" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN 1"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 
 resource "packet_vlan" "test2" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN 2"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -157,7 +157,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facilities       = ["dfw2"]
+  facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -165,8 +165,8 @@ resource "packet_device" "test" {
 }
 
 resource "packet_vlan" "test" {
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test vlan"
+  facility    = "nrt1"
   project_id  = "${packet_project.test.id}"
 }
 
@@ -178,7 +178,7 @@ resource "packet_port_vlan_attachment" "test" {
 }`, name)
 }
 
-func TestAccPacketPortVlanAttachment_Hybrid(t *testing.T) {
+func TestAccPacketPortVlanAttachment_HybridBasic(t *testing.T) {
 	rs := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -209,7 +209,7 @@ resource "packet_project" "test" {
 resource "packet_device" "test" {
   hostname         = "test"
   plan             = "s1.large.x86"
-  facilities       = ["dfw2"]
+  facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = packet_project.test.id
@@ -218,8 +218,8 @@ resource "packet_device" "test" {
 
 resource "packet_vlan" "test" {
   count       = 3
-  description = "VLAN in New Jersey"
-  facility    = "dfw2"
+  description = "test VLAN"
+  facility    = "nrt1"
   project_id  = packet_project.test.id
 }
 


### PR DESCRIPTION
The Acceptance tests for VLAN attachment notoriously fail (#182). 

They fail either because facility `dfw2` is out of capacity of L2-capacble device plans, or there are timeouts.

This PR will switch the facility to "nrt1", hopefully making the tests succeed for some time. This is obviously just a temporary solution, but it's good to see the VLAN tests succeed again, after quite some changes in the provider.

Permanent solution would be to get the capacity via a datasource and run the test devices where the capacity is not "unavailable".

closes #182 temporarily