### PR TITLE
removed packet_conect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.6.3 (Unreleased)
+## 2.7.0 (Unreleased)
+
+FEATURES
+- [#201] (https://github.com/terraform-providers/terraform-provider-packet/issues/201) Removed resorce packet_connect
+
 ## 2.6.2 (November 16, 2019)
 
 FEATURES

--- a/packet/resource_packet_connect.go
+++ b/packet/resource_packet_connect.go
@@ -3,6 +3,7 @@
 package packet
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -98,45 +99,11 @@ func connectRefreshFunc(d *schema.ResourceData, meta interface{}) resource.State
 }
 
 func resourcePacketConnectCreate(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*packngo.Client)
-	createRequest := &packngo.ConnectCreateRequest{
-		ProjectID:       d.Get("project_id").(string),
-		ProviderID:      d.Get("provider_id").(string),
-		Name:            d.Get("name").(string),
-		Facility:        d.Get("facility").(string),
-		ProviderPayload: d.Get("provider_payload").(string),
-		VLAN:            d.Get("vxlan").(int),
-		PortSpeed:       d.Get("port_speed").(int),
-		Description:     d.Get("name").(string),
-		Tags:            []string{d.Get("name").(string)},
-	}
-
-	pc, _, err := c.Connects.Create(createRequest)
-	if err != nil {
-		return friendlyError(err)
-	}
-	d.SetId(pc.ID)
-	_, err = waitForConnectStatus(d, "PROVISIONED", "PROVISIONING", meta)
-	if err != nil {
-		return friendlyError(err)
-	}
-	return resourcePacketConnectRead(d, meta)
+	return fmt.Errorf("packet_connect is deprecated in provider version 2.7.0")
 }
 
 func resourcePacketConnectRead(d *schema.ResourceData, meta interface{}) error {
-	c := meta.(*packngo.Client)
-	pc, _, err := c.Connects.Get(d.Id(), d.Get("project_id").(string), nil)
-	if err != nil {
-		return friendlyError(err)
-	}
-	d.Set("name", pc.Name)
-	d.Set("provider_id", pc.ProviderID)
-	d.Set("provider_payload", pc.ProviderPayload)
-	d.Set("status", pc.Status)
-	d.Set("port_speed", pc.PortSpeed)
-	d.Set("vxlan", pc.VLAN)
-
-	return nil
+	return fmt.Errorf("packet_connect is deprecated in provider version 2.7.0")
 }
 
 func resourcePacketConnectDelete(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/r/connect.html.markdown
+++ b/website/docs/r/connect.html.markdown
@@ -3,54 +3,10 @@ layout: "packet"
 page_title: "Packet: packet_connect"
 sidebar_current: "docs-packet-resource-connect"
 description: |-
-  Provides a resource for Packet Connect, which is now deprecated and will be fully removed in release 2.7.0.
+  Packet Connect resource was removed in version 2.7.0.
 ---
 
 # packet_connect
 
-Provides a resource for [Packet Connect](https://www.packet.com/cloud/all-features/packet-connect/), a link between Packet VLANs and VLANs in other cloud providers, which is now deprecated. Packet Connect will be fully removed in release 2.7.0.
+Packet Connect was removed in release 2.7.0.
 
-## Example Usage
-
-```hcl
-# Create a new VLAN in ewr1 and connect it to Azure ExpressRoute 
-
-resource "packet_vlan" "vlan1" {
-  description = "VLAN in New Jersey"
-  facility    = "ewr1"
-  project_id  = "${local.project_id}"
-}
-
-resource "packet_connect" "my_expressroute" {
-  name        = "test"
-  facility    = "ewr1"
-  project_id  = "${local.project_id}"
-  # provider ID for Azure ExpressRoute is ed5de8e0-77a9-4d3b-9de0-65281d3aa831
-  provider_id = "ed5de8e0-77a9-4d3b-9de0-65281d3aa831"
-  # provider_payload for Azure ExpressRoute provider is your ExpressRoute
-  # authorization key (in UUID format)
-  provider_payload = "58b4ec12-af34-4435-5435-db3bde4a4b3a"
-  port_speed  = 100
-  vxlan       = "${packet_vlan.vlan1.vxlan}"
-}
-
-```
-
-## Argument Reference
-
-The following arguments are supported:
-
-* `name` - (Required) Name for the Connect resource
-* `facility` - (Required) Facility where to create the VLAN
-* `project_id` - (Required) ID of parent project
-* `provider_id` - (Required) ID of Connect Provider. Provider IDs are
-  * Azure ExpressRoute - "ed5de8e0-77a9-4d3b-9de0-65281d3aa831"
-* `provider_payload` - (Required) Authorization key for the Connect provider
-* `port_speed` - (Required) Port speed in Mbps
-* `vxlan` - (Required) VXLAN Network identifier of the linked Packet VLAN
-
-## Attributes Reference
-
-The following attributes are exported:
-
-* `status` - Status of the Connect resource, one of PROVISIONING, PROVISIONED, DEPROVISIONING, DEPROVISIONED

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -50,9 +50,6 @@
             <li<%= sidebar_current("docs-packet-resource-bgp-session") %>>
               <a href="/docs/providers/packet/r/bgp_session.html">packet_bgp_session</a>
             </li>
-            <li<%= sidebar_current("docs-packet-resource-connect") %>>
-              <a href="/docs/providers/packet/r/connect.html">packet_connect</a>
-            </li>
             <li<%= sidebar_current("docs-packet-resource-device") %>>
               <a href="/docs/providers/packet/r/device.html">packet_device</a>
             </li>


### PR DESCRIPTION
Removing packet_connect, major release, according to https://www.terraform.io/docs/extend/best-practices/deprecations.html#provider-data-source-or-resource-removal