### PR TITLE
Use the address family provided, rather than just ipv4

### DIFF
--- a/packet/resource_packet_bgp_session.go
+++ b/packet/resource_packet_bgp_session.go
@@ -52,7 +52,7 @@ func resourcePacketBGPSessionCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] creating %s BGP session to device (%s)\n", addressFamily, dID)
 	bgpSession, _, err := client.BGPSessions.Create(
 		dID, packngo.CreateBGPSessionRequest{
-			AddressFamily: "ipv4",
+			AddressFamily: addressFamily,
 			DefaultRoute:  &defaultRoute})
 	if err != nil {
 		return friendlyError(err)

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -26,6 +26,10 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 						"packet_bgp_session.test", "device_id"),
 					resource.TestCheckResourceAttr(
 						"packet_bgp_session.test", "default_route", "true"),
+					resource.TestCheckResourceAttr(
+						"packet_bgp_session.test4", "address_family", "ipv4"),
+					resource.TestCheckResourceAttr(
+						"packet_bgp_session.test6", "address_family", "ipv6"),
 				),
 			},
 			{
@@ -72,9 +76,16 @@ resource "packet_device" "test" {
     project_id       = "${packet_project.test.id}"
 }
 
-resource "packet_bgp_session" "test" {
+resource "packet_bgp_session" "test4 {
 	device_id = "${packet_device.test.id}"
 	address_family = "ipv4"
 	default_route = true
-}`, name)
+}
+
+resource "packet_bgp_session" "test6" {
+	device_id = "${packet_device.test.id}"
+	address_family = "ipv6"
+	default_route = true
+}
+`, name)
 }

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -23,9 +23,14 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
 						"packet_device.test", "id",
-						"packet_bgp_session.test", "device_id"),
+						"packet_bgp_session.test4", "device_id"),
+					resource.TestCheckResourceAttrPair(
+						"packet_device.test", "id",
+						"packet_bgp_session.test6", "device_id"),
 					resource.TestCheckResourceAttr(
-						"packet_bgp_session.test", "default_route", "true"),
+						"packet_bgp_session.test4", "default_route", "true"),
+					resource.TestCheckResourceAttr(
+						"packet_bgp_session.test6", "default_route", "true"),
 					resource.TestCheckResourceAttr(
 						"packet_bgp_session.test4", "address_family", "ipv4"),
 					resource.TestCheckResourceAttr(
@@ -33,7 +38,7 @@ func TestAccPacketBGPSession_Basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "packet_bgp_session.test",
+				ResourceName:      "packet_bgp_session.test4",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -76,7 +81,7 @@ resource "packet_device" "test" {
     project_id       = "${packet_project.test.id}"
 }
 
-resource "packet_bgp_session" "test4 {
+resource "packet_bgp_session" "test4" {
 	device_id = "${packet_device.test.id}"
 	address_family = "ipv4"
 	default_route = true


### PR DESCRIPTION
This patch would create the BGP session using the provided address
family.

The tests provided in this patch would not actually catch the error,
since they since they jsut test for valid configuraiton, not the objects
used when the session is created.

By the way, I have not tested this patch in any way.

Maybe fixes https://github.com/terraform-providers/terraform-provider-packet/issues/206