### PR TITLE
Fix "reserve_ip_block" when API returns 404

### DIFF
--- a/packet/resource_packet_reserved_ip_block.go
+++ b/packet/resource_packet_reserved_ip_block.go
@@ -212,10 +212,6 @@ func resourcePacketReservedIPBlockRead(d *schema.ResourceData, meta interface{})
 	reservedBlock, _, err := client.ProjectIPs.Get(id, nil)
 	if err != nil {
 		err = friendlyError(err)
-		if isNotFound(err) {
-			d.SetId("")
-			return nil
-		}
 		return fmt.Errorf("Error reading IP address block with ID %s: %s", id, err)
 	}
 	err = loadBlock(d, reservedBlock)


### PR DESCRIPTION
This block cause terraform to delete all information from the state if Packet's API returns 404. It's better to have terraform fail than make it act as the resource was destroyed.