### PR TITLE
check if HTTP 404 Not Found comes indeed from API

### DIFF
--- a/packet/errors.go
+++ b/packet/errors.go
@@ -9,16 +9,28 @@ import (
 
 func friendlyError(err error) error {
 	if e, ok := err.(*packngo.ErrorResponse); ok {
+		resp := e.Response
 		errors := Errors(e.Errors)
 		// if packngo gives us blank error strings, populate them with something useful
 		// this is useful so the user gets some sort of indication of a failure rather than a blank message
 		if 0 == len(errors) {
 			errors = Errors{e.SingleError}
 		}
-		return &ErrorResponse{
-			StatusCode: e.Response.StatusCode,
+		er := &ErrorResponse{
+			StatusCode: resp.StatusCode,
 			Errors:     errors,
 		}
+		respHead := resp.Header
+
+		// this checks if the error comes from API (and not from cache/LB)
+		if len(errors) > 0 {
+			ct := respHead.Get("Content-Type")
+			xrid := respHead.Get("X-Request-Id")
+			if strings.Contains(ct, "application/json") && len(xrid) > 0 {
+				er.IsAPIError = true
+			}
+		}
+		return er
 	}
 	return err
 }
@@ -32,7 +44,7 @@ func isForbidden(err error) bool {
 
 func isNotFound(err error) bool {
 	if r, ok := err.(*ErrorResponse); ok {
-		return r.StatusCode == http.StatusNotFound
+		return r.StatusCode == http.StatusNotFound && r.IsAPIError
 	}
 	return false
 }
@@ -46,4 +58,5 @@ func (e Errors) Error() string {
 type ErrorResponse struct {
 	StatusCode int
 	Errors
+	IsAPIError bool
 }


### PR DESCRIPTION
This is a result of discussion with @smintz 

When terraform provider gets 404 NotFound on a resource which is listed in the tf state (was created or imported by/to terraform), the standard way to handle this is to remove the resource from the state and consider it gone. Subsequent `apply` will attempt to create the resource again.

@smintz mentioned that he was running to problems when HTTP 404 was returned by the load balancer (instead of the API). The resource still exists, but terraform then forgets about it, and attempts to re-create. This is obviously not good, it would be better to raise the 404 Error from the load balancer.

The goal of this PR is to distinguish HTTP 404 from API and from load balancer. If it's 404 from the API, the resource is marked as gone, but if it's not, the error is raised so that user can act on it.

The way I distinguish the errors in the code is a bit clumsy. It was discussed with @smintz and it seems this is the best what we can do with the current state of things. If you have an idea how to do this better, let me know here.

As this is quite a hack, I would like to get green light from more than one Packet engineers. 

closes #209 