### PR TITLE
Add sweepers to clean residual resources from Acceptance tests

### DIFF
--- a/packet/datasource_packet_device_test.go
+++ b/packet/datasource_packet_device_test.go
@@ -20,7 +20,7 @@ func TestAccDataSourcePacketDevice_Basic(t *testing.T) {
 				Config: testDataSourcePacketDeviceConfig_Basic(projectName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.packet_device.test", "hostname", "test-device"),
+						"data.packet_device.test", "hostname", "tfacc-test-device"),
 					resource.TestCheckResourceAttrPair(
 						"packet_device.test", "id",
 						"data.packet_device.test", "id"),
@@ -44,7 +44,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device"
+  hostname         = "tfacc-test-device"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
@@ -70,7 +70,7 @@ func TestAccDataSourcePacketDevice_ByID(t *testing.T) {
 				Config: testDataSourcePacketDeviceConfig_ByID(projectName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.packet_device.test", "hostname", "test-device"),
+						"data.packet_device.test", "hostname", "tfacc-test-device"),
 					resource.TestCheckResourceAttrPair(
 						"packet_device.test", "id",
 						"data.packet_device.test", "id"),
@@ -94,7 +94,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device"
+  hostname         = "tfacc-test-device"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"

--- a/packet/datasource_packet_ip_block_ranges_test.go
+++ b/packet/datasource_packet_ip_block_ranges_test.go
@@ -43,7 +43,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "tftest"
+  hostname         = "tfacc-device-ip-test"
   plan             = "t1.small.x86"
   facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"

--- a/packet/datasource_packet_organization_test.go
+++ b/packet/datasource_packet_organization_test.go
@@ -21,11 +21,11 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
 					resource.TestCheckResourceAttr(
-						"packet_organization.test", "name", "TF Datasource test Org"),
+						"packet_organization.test", "name", "tfacc-datasource-org"),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "description", "quux"),
 					resource.TestCheckResourceAttr(
-						"data.packet_organization.test", "name", "TF Datasource test Org"),
+						"data.packet_organization.test", "name", "tfacc-datasource-org"),
 					resource.TestCheckResourceAttrPair(
 						"data.packet_organization.test2", "id", "packet_organization.test", "id"),
 				),
@@ -36,7 +36,7 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 
 var testAccCheckPacketOrgDataSourceConfigBasic = fmt.Sprintf(`
 resource "packet_organization" "test" {
-		name = "TF Datasource test Org"
+		name = "tfacc-datasource-org"
 		description = "quux"
 }
 

--- a/packet/datasource_packet_precreated_ip_block_test.go
+++ b/packet/datasource_packet_precreated_ip_block_test.go
@@ -43,7 +43,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "tftest"
+  hostname         = "tfacc-test-device-ip-blockt"
   plan             = "t1.small.x86"
   facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"

--- a/packet/datasource_packet_spot_market_request_test.go
+++ b/packet/datasource_packet_spot_market_request_test.go
@@ -46,7 +46,7 @@ resource "packet_spot_market_request" "req" {
   wait_for_devices = true
 
   instance_parameters {
-    hostname         = "testspot"
+    hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "ubuntu_16_04"
     plan             = "t1.small.x86"

--- a/packet/datasource_packet_volume_test.go
+++ b/packet/datasource_packet_volume_test.go
@@ -45,7 +45,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-    hostname         = "terraform-test-device-volume-datasource"
+    hostname         = "tfacc-device-volume-datasource"
     plan             = "t1.small.x86"
     facilities       = ["ewr1"]
     operating_system = "ubuntu_16_04"

--- a/packet/resource_packet_bgp_session_test.go
+++ b/packet/resource_packet_bgp_session_test.go
@@ -73,7 +73,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-    hostname         = "terraform-test-bgp-sesh"
+    hostname         = "tfacc-test-bgp-sesh"
     plan             = "t1.small.x86"
     facilities       = ["ewr1"]
     operating_system = "ubuntu_16_04"

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -2,8 +2,10 @@ package packet
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -11,6 +13,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/packethost/packngo"
 )
+
+func init() {
+	resource.AddTestSweepers("packet_device", &resource.Sweeper{
+		Name: "packet_device",
+		F:    testSweepDevices,
+	})
+}
+
+func testSweepDevices(region string) error {
+	log.Printf("[DEBUG] Sweeping devices")
+	meta, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client for sweeping devices: %s", err)
+	}
+	client := meta.(*packngo.Client)
+
+	ps, _, err := client.Projects.List(nil)
+	if err != nil {
+		return fmt.Errorf("Error getting project list for sweepeing devices: %s", err)
+	}
+	pids := []string{}
+	for _, p := range ps {
+		if strings.HasPrefix(p.Name, "tfacc-") {
+			pids = append(pids, p.ID)
+		}
+	}
+	dids := []string{}
+	for _, pid := range pids {
+		ds, _, err := client.Devices.List(pid, nil)
+		if err != nil {
+			return fmt.Errorf("Error listing devices to sweep: %s", err)
+		}
+		for _, d := range ds {
+			if strings.HasPrefix(d.Hostname, "tfacc-") {
+				dids = append(dids, d.ID)
+			}
+		}
+	}
+
+	for _, did := range dids {
+		log.Printf("Removing device %s", did)
+		_, err := client.Devices.Delete(did, true)
+		if err != nil {
+			return fmt.Errorf("Error deleting device %s", err)
+		}
+	}
+	return nil
+}
 
 // Regexp vars for use with resource.ExpectError
 var matchErrMustBeProvided = regexp.MustCompile(".* must be provided when .*")

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -119,14 +119,14 @@ func TestAccPacketDevice_Update(t *testing.T) {
 				Config: testAccCheckPacketDeviceConfig_varname(rInt, rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketDeviceExists(r, &d1),
-					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("test-device-%d", rInt)),
+					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("tfacc-test-device-%d", rInt)),
 				),
 			},
 			{
 				Config: testAccCheckPacketDeviceConfig_varname(rInt+1, rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketDeviceExists(r, &d2),
-					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("test-device-%d", rInt+1)),
+					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("tfacc-test-device-%d", rInt+1)),
 					testAccCheckPacketSameDevice(t, &d1, &d2),
 				),
 			},
@@ -134,7 +134,7 @@ func TestAccPacketDevice_Update(t *testing.T) {
 				Config: testAccCheckPacketDeviceConfig_varname(rInt+2, rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketDeviceExists(r, &d3),
-					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("test-device-%d", rInt+2)),
+					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("tfacc-test-device-%d", rInt+2)),
 					resource.TestCheckResourceAttr(r, "description", fmt.Sprintf("test-desc-%d", rInt+2)),
 					resource.TestCheckResourceAttr(r, "tags.0", fmt.Sprintf("%d", rInt+2)),
 					testAccCheckPacketSameDevice(t, &d2, &d3),
@@ -144,7 +144,7 @@ func TestAccPacketDevice_Update(t *testing.T) {
 				Config: testAccCheckPacketDeviceConfig_no_description(rInt+3, rs),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketDeviceExists(r, &d4),
-					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("test-device-%d", rInt+3)),
+					resource.TestCheckResourceAttr(r, "hostname", fmt.Sprintf("tfacc-test-device-%d", rInt+3)),
 					resource.TestCheckResourceAttr(r, "tags.0", fmt.Sprintf("%d", rInt+3)),
 					testAccCheckPacketSameDevice(t, &d3, &d4),
 				),
@@ -215,11 +215,11 @@ func TestAccPacketDevice_IPXEScriptUrl(t *testing.T) {
 func testAccCheckPacketDeviceConfig_L2(projSuffix string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
-    name = "tfacc-device-%s"
+    name = "tfacc-project-%s"
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-device-L2-test"
   plan             = "m1.xlarge.x86"
   facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"
@@ -308,7 +308,7 @@ func testAccCheckPacketDeviceDestroy(s *terraform.State) error {
 
 func testAccCheckPacketDeviceAttributes(device *packngo.Device) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if device.Hostname != "test-device" {
+		if device.Hostname != "tfacc-test-device" {
 			return fmt.Errorf("Bad name: %s", device.Hostname)
 		}
 		if device.State != "active" {
@@ -462,7 +462,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device-%d"
+  hostname         = "tfacc-test-device-%d"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
@@ -480,7 +480,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device-%d"
+  hostname         = "tfacc-test-device-%d"
   description      = "test-desc-%d"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
@@ -499,7 +499,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device-%d"
+  hostname         = "tfacc-test-device-%d"
   description      = "test-desc-%d"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
@@ -520,7 +520,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device"
+  hostname         = "tfacc-test-device"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
@@ -541,7 +541,7 @@ locals {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test-device"
+  hostname         = "tfacc-test-device"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "ubuntu_16_04"
@@ -575,7 +575,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test"  {
 
-  hostname         = "test-ipxe-script-url"
+  hostname         = "tfacc-device-test-ipxe-script-url"
   plan             = "t1.small.x86"
   facilities       = ["sjc1", "any"]
   operating_system = "ubuntu_16_04"
@@ -592,7 +592,7 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test_ipxe_script_url"  {
 
-  hostname         = "test-ipxe-script-url"
+  hostname         = "tfacc-device-test-ipxe-script-url"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "custom_ipxe"
@@ -610,7 +610,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test_ipxe_conflict" {
-  hostname         = "test-ipxe-conflict"
+  hostname         = "tfacc-device-test-ipxe-conflict"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "custom_ipxe"
@@ -627,7 +627,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test_ipxe_missing" {
-  hostname         = "test-ipxe-missing"
+  hostname         = "tfacc-device-test-ipxe-missing"
   plan             = "t1.small.x86"
   facilities       = ["sjc1"]
   operating_system = "custom_ipxe"

--- a/packet/resource_packet_ip_attachment_test.go
+++ b/packet/resource_packet_ip_attachment_test.go
@@ -60,7 +60,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-device-ip-attachment-test"
   plan             = "t1.small.x86"
   facilities       = ["ewr1"]
   operating_system = "ubuntu_16_04"

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -22,7 +22,7 @@ func TestAccOrgCreate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
 					resource.TestCheckResourceAttr(
-						"packet_organization.test", "name", "foobar"),
+						"packet_organization.test", "name", "tfacc-org"),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "description", "quux"),
 				),
@@ -92,6 +92,6 @@ func testAccCheckPacketOrgExists(n string, org *packngo.Organization) resource.T
 
 var testAccCheckPacketOrgConfigBasic = fmt.Sprintf(`
 resource "packet_organization" "test" {
-		name = "foobar"
+		name = "tfacc-org"
 		description = "quux"
 }`)

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -19,7 +19,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-device-port-vlan-attachment-test"
   plan             = "s1.large.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
@@ -87,7 +87,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-vlan-l2i-test"
   plan             = "s1.large.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
@@ -155,7 +155,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-device-hybrid-test"
   plan             = "s1.large.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
@@ -207,7 +207,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-device-hmv-test"
   plan             = "s1.large.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"
@@ -303,7 +303,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-  hostname         = "test"
+  hostname         = "tfacc-device-l2n-test"
   plan             = "s1.large.x86"
   facilities       = ["nrt1"]
   operating_system = "ubuntu_16_04"

--- a/packet/resource_packet_project_ssh_key_test.go
+++ b/packet/resource_packet_project_ssh_key_test.go
@@ -18,13 +18,13 @@ resource "packet_project" "test" {
 }
 
 resource "packet_project_ssh_key" "test" {
-    name = "test"
+    name = "tfacc-project-key-test"
     public_key = "%s"
     project_id = "${packet_project.test.id}"
 }
 
 resource "packet_device" "test" {
-    hostname            = "test"
+    hostname            = "tfacc-device-key-test"
     plan                = "baremetal_0"
     facilities          = ["ewr1"]
     operating_system    = "ubuntu_16_04"

--- a/packet/resource_packet_project_test.go
+++ b/packet/resource_packet_project_test.go
@@ -2,7 +2,9 @@ package packet
 
 import (
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -10,6 +12,42 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/packethost/packngo"
 )
+
+func init() {
+	resource.AddTestSweepers("packet_project", &resource.Sweeper{
+		Name:         "packet_project",
+		Dependencies: []string{"packet_device"},
+		F:            testSweepProjects,
+	})
+}
+
+func testSweepProjects(region string) error {
+	log.Printf("[DEBUG] Sweeping projects")
+	meta, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client for sweeping projects: %s", err)
+	}
+	client := meta.(*packngo.Client)
+
+	ps, _, err := client.Projects.List(nil)
+	if err != nil {
+		return fmt.Errorf("Error getting project list for sweepeing projects: %s", err)
+	}
+	pids := []string{}
+	for _, p := range ps {
+		if strings.HasPrefix(p.Name, "tfacc-") {
+			pids = append(pids, p.ID)
+		}
+	}
+	for _, pid := range pids {
+		log.Printf("Removing project %s", pid)
+		_, err := client.Projects.Delete(pid)
+		if err != nil {
+			return fmt.Errorf("Error deleting project %s", err)
+		}
+	}
+	return nil
+}
 
 func TestAccPacketProject_Basic(t *testing.T) {
 	var project packngo.Project

--- a/packet/resource_packet_spot_market_request.go
+++ b/packet/resource_packet_spot_market_request.go
@@ -109,7 +109,10 @@ func resourcePacketSpotMarketRequest() *schema.Resource {
 				ForceNew: true,
 			},
 		},
-		Timeouts: resourceDefaultTimeouts,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
 	}
 }
 

--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -88,7 +88,7 @@ resource "packet_spot_market_request" "request" {
   wait_for_devices = true
 
   instance_parameters {
-    hostname         = "testspot"
+    hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "coreos_stable"
     plan             = "t1.small.x86"

--- a/packet/resource_packet_ssh_key_test.go
+++ b/packet/resource_packet_ssh_key_test.go
@@ -28,7 +28,7 @@ func TestAccPacketSSHKey_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketSSHKeyExists("packet_ssh_key.foobar", &key),
 					resource.TestCheckResourceAttr(
-						"packet_ssh_key.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
+						"packet_ssh_key.foobar", "name", fmt.Sprintf("tfacc-user-key-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"packet_ssh_key.foobar", "public_key", publicKeyMaterial),
 					resource.TestCheckResourceAttrSet(
@@ -82,7 +82,7 @@ func TestAccPacketSSHKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketSSHKeyExists("packet_ssh_key.foobar", &key),
 					resource.TestCheckResourceAttr(
-						"packet_ssh_key.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
+						"packet_ssh_key.foobar", "name", fmt.Sprintf("tfacc-user-key-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"packet_ssh_key.foobar", "public_key", publicKeyMaterial),
 				),
@@ -92,7 +92,7 @@ func TestAccPacketSSHKey_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketSSHKeyExists("packet_ssh_key.foobar", &key),
 					resource.TestCheckResourceAttr(
-						"packet_ssh_key.foobar", "name", fmt.Sprintf("foobar-%d", rInt+1)),
+						"packet_ssh_key.foobar", "name", fmt.Sprintf("tfacc-user-key-%d", rInt+1)),
 					resource.TestCheckResourceAttr(
 						"packet_ssh_key.foobar", "public_key", publicKeyMaterial),
 				),
@@ -190,7 +190,7 @@ func testAccCheckPacketSSHKeyExists(n string, key *packngo.SSHKey) resource.Test
 func testAccCheckPacketSSHKeyConfig_basic(rInt int, publicSshKey string) string {
 	return fmt.Sprintf(`
 resource "packet_ssh_key" "foobar" {
-    name = "foobar-%d"
+    name = "tfacc-user-key-%d"
     public_key = "%s"
 }`, rInt, publicSshKey)
 }
@@ -199,11 +199,11 @@ func testAccCheckPacketSSHKeyConfig_projectBasic(rInt int, publicSshKey string) 
 	return fmt.Sprintf(`
 
 resource "packet_project" "test" {
-    name = "test-%d"
+    name = "tfacc-project-key-test-%d"
 }
 
 resource "packet_project_ssh_key" "foobar" {
-    name = "foobar-%d"
+    name = "tfacc-project-key-%d"
     public_key = "%s"
 	project_id = packet_project.test.id
 }`, rInt, rInt, publicSshKey)

--- a/packet/resource_packet_volume_attachment_test.go
+++ b/packet/resource_packet_volume_attachment_test.go
@@ -60,7 +60,7 @@ resource "packet_project" "test" {
 }
 
 resource "packet_device" "test" {
-    hostname         = "terraform-test-device-va"
+    hostname         = "tfacc-test-device-va"
     plan             = "t1.small.x86"
     facilities       = ["ewr1"]
     operating_system = "ubuntu_16_04"

--- a/packet/sweeper_test.go
+++ b/packet/sweeper_test.go
@@ -1,0 +1,26 @@
+package packet
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sharedConfigForRegion(region string) (interface{}, error) {
+
+	if os.Getenv("PACKET_AUTH_TOKEN") == "" {
+		return nil, fmt.Errorf("you must set PACKET_AUTH_TOKEN")
+	}
+
+	config := Config{
+		AuthToken: os.Getenv("PACKET_AUTH_TOKEN"),
+	}
+
+	return config.Client(), nil
+}


### PR DESCRIPTION
We had congestion of the Terraform test account. This PR adds sweepers to clean resoruces from failed tests.