### PR TITLE
Improve packet_spot_market_request test

### DIFF
--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -25,7 +25,6 @@ func TestAccPacketSpotMarketRequest_Basic(t *testing.T) {
 					testAccCheckPacketSpotMarketRequestExists("packet_spot_market_request.request", &key),
 					resource.TestCheckResourceAttr("packet_spot_market_request.request", "devices_max", "1"),
 					resource.TestCheckResourceAttr("packet_spot_market_request.request", "devices_min", "1"),
-					resource.TestCheckResourceAttr("packet_spot_market_request.request", "max_bid_price", "0.03"),
 				),
 			},
 		},
@@ -79,9 +78,15 @@ resource "packet_project" "test" {
   name = "tfacc-spot_market_request-%s"
 }
 
+data "packet_spot_market_price" "test" {
+  facility = "ewr1"
+  plan     = "baremetal_0"
+}
+
+
 resource "packet_spot_market_request" "request" {
   project_id       = "${packet_project.test.id}"
-  max_bid_price    = 0.03
+  max_bid_price    = data.packet_spot_market_price.test.price * 1.2
   facilities       = ["ewr1"]
   devices_min      = 1
   devices_max      = 1
@@ -91,7 +96,7 @@ resource "packet_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "coreos_stable"
-    plan             = "t1.small.x86"
+    plan             = "baremetal_0"
   }
 }`, name)
 }


### PR DESCRIPTION
The acceptance test of packet_spot_market_request is notoriously failing in the Hashicorp Teamcity CI. It's because the max_bid price for request in the test is hardcoded, and when the spot price fluctuates, the request might never be fulfilled.

This PR makes the smr test aware of the spot price (using datasource for spot market price), and sets the max bid to 120% of the current price. This, in theory, makes the request guaranteed to be fullfilled and devices created under it.