### PR TITLE
Compound Hotix: volume sweeper, TF state fix, spot market test fix

### DIFF
--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -425,17 +425,18 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 	// Wait for the device so we can get the networking attributes that show up after a while.
 	state, err := waitForDeviceAttribute(d, []string{"active", "failed"}, []string{"queued", "provisioning"}, "state", meta)
 	if err != nil {
-		if isForbidden(err) {
+		d.SetId("")
+		fErr := friendlyError(err)
+		if isForbidden(fErr) {
 			// If the device doesn't get to the active state, we can't recover it from here.
-			d.SetId("")
 
 			return errors.New("provisioning time limit exceeded; the Packet team will investigate")
 		}
-		return err
+		return fErr
 	}
 	if state != "active" {
 		d.SetId("")
-		return friendlyError(fmt.Errorf("Device in non-active state \"%s\"", state))
+		return fmt.Errorf("Device in non-active state \"%s\"", state)
 	}
 
 	if nTypeOk {

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -18,6 +18,7 @@ func init() {
 	resource.AddTestSweepers("packet_device", &resource.Sweeper{
 		Name: "packet_device",
 		F:    testSweepDevices,
+        Dependencies: []string{"packet_volume"},
 	})
 }
 

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -16,9 +16,9 @@ import (
 
 func init() {
 	resource.AddTestSweepers("packet_device", &resource.Sweeper{
-		Name: "packet_device",
-		F:    testSweepDevices,
-        Dependencies: []string{"packet_volume"},
+		Name:         "packet_device",
+		F:            testSweepDevices,
+		Dependencies: []string{"packet_volume"},
 	})
 }
 
@@ -47,9 +47,7 @@ func testSweepDevices(region string) error {
 			return fmt.Errorf("Error listing devices to sweep: %s", err)
 		}
 		for _, d := range ds {
-			if strings.HasPrefix(d.Hostname, "tfacc-") {
-				dids = append(dids, d.ID)
-			}
+			dids = append(dids, d.ID)
 		}
 	}
 

--- a/packet/resource_packet_spot_market_request_test.go
+++ b/packet/resource_packet_spot_market_request_test.go
@@ -25,7 +25,6 @@ func TestAccPacketSpotMarketRequest_Basic(t *testing.T) {
 					testAccCheckPacketSpotMarketRequestExists("packet_spot_market_request.request", &key),
 					resource.TestCheckResourceAttr("packet_spot_market_request.request", "devices_max", "1"),
 					resource.TestCheckResourceAttr("packet_spot_market_request.request", "devices_min", "1"),
-					resource.TestCheckResourceAttr("packet_spot_market_request.request", "max_bid_price", "0.03"),
 				),
 			},
 		},
@@ -79,9 +78,15 @@ resource "packet_project" "test" {
   name = "tfacc-spot_market_request-%s"
 }
 
+data "packet_spot_market_price" "test" {
+  facility = "ewr1"
+  plan     = "baremetal_0"
+}
+
+
 resource "packet_spot_market_request" "request" {
   project_id       = "${packet_project.test.id}"
-  max_bid_price    = 0.03
+  max_bid_price    = data.packet_spot_market_price.test.price * 1.2
   facilities       = ["ewr1"]
   devices_min      = 1
   devices_max      = 1
@@ -91,7 +96,7 @@ resource "packet_spot_market_request" "request" {
     hostname         = "tfacc-testspot"
     billing_cycle    = "hourly"
     operating_system = "coreos_stable"
-    plan             = "t1.small.x86"
+    plan             = "baremetal_0"
   }
 }`, name)
 }

--- a/packet/resource_packet_volume_test.go
+++ b/packet/resource_packet_volume_test.go
@@ -2,6 +2,8 @@ package packet
 
 import (
 	"fmt"
+	"log"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -9,6 +11,52 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/packethost/packngo"
 )
+
+func init() {
+	resource.AddTestSweepers("packet_volume", &resource.Sweeper{
+		Name: "packet_volume",
+		F:    testSweepVolumes,
+	})
+}
+
+func testSweepVolumes(region string) error {
+	log.Printf("[DEBUG] Sweeping volumes")
+	meta, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client for sweeping volumes: %s", err)
+	}
+	client := meta.(*packngo.Client)
+
+	ps, _, err := client.Projects.List(nil)
+	if err != nil {
+		return fmt.Errorf("Error getting project list for sweepeing volumes: %s", err)
+	}
+	pids := []string{}
+	for _, p := range ps {
+		if strings.HasPrefix(p.Name, "tfacc-") {
+			pids = append(pids, p.ID)
+		}
+	}
+	vids := []string{}
+	for _, pid := range pids {
+		vs, _, err := client.Volumes.List(pid, nil)
+		if err != nil {
+			return fmt.Errorf("Error listing volumes to sweep: %s", err)
+		}
+		for _, v := range vs {
+			vids = append(vids, v.ID)
+		}
+	}
+
+	for _, vid := range vids {
+		log.Printf("Removing volume %s", vid)
+		_, err := client.Volumes.Delete(vid)
+		if err != nil {
+			return fmt.Errorf("Error deleting volume %s", err)
+		}
+	}
+	return nil
+}
 
 func TestAccPacketVolume_Basic(t *testing.T) {
 	var volume packngo.Volume

--- a/packet/resource_packet_volume_test.go
+++ b/packet/resource_packet_volume_test.go
@@ -95,7 +95,7 @@ func TestAccPacketVolume_Update(t *testing.T) {
 		CheckDestroy: testAccCheckPacketVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketVolumeConfig_var(rs, 10, "descstr", "storage_1", true),
+				Config: testAccCheckPacketVolumeConfig_var(rs, 100, "descstr", "storage_1", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketVolumeExists("packet_volume.foobar", &volume),
 					resource.TestCheckResourceAttr(
@@ -103,7 +103,7 @@ func TestAccPacketVolume_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckPacketVolumeConfig_var(rs, 10, "descstr", "storage_1", false),
+				Config: testAccCheckPacketVolumeConfig_var(rs, 100, "descstr", "storage_1", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketVolumeExists("packet_volume.foobar", &v1),
 					resource.TestCheckResourceAttr(
@@ -112,7 +112,7 @@ func TestAccPacketVolume_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckPacketVolumeConfig_var(rs, 10, "descstr2", "storage_2", false),
+				Config: testAccCheckPacketVolumeConfig_var(rs, 100, "descstr2", "storage_2", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketVolumeExists("packet_volume.foobar", &v2),
 					resource.TestCheckResourceAttr(
@@ -121,16 +121,16 @@ func TestAccPacketVolume_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckPacketVolumeConfig_var(rs, 20, "descstr2", "storage_2", false),
+				Config: testAccCheckPacketVolumeConfig_var(rs, 102, "descstr2", "storage_2", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketVolumeExists("packet_volume.foobar", &v3),
 					resource.TestCheckResourceAttr(
-						"packet_volume.foobar", "size", "20"),
+						"packet_volume.foobar", "size", "102"),
 					testAccCheckPacketSameVolume(t, &volume, &v3),
 				),
 			},
 			{
-				Config: testAccCheckPacketVolumeConfig_var(rs, 22, "descstr2", "storage_2", true),
+				Config: testAccCheckPacketVolumeConfig_var(rs, 104, "descstr2", "storage_2", true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketVolumeExists("packet_volume.foobar", &v4),
 					resource.TestCheckResourceAttr(
@@ -139,7 +139,7 @@ func TestAccPacketVolume_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckPacketVolumeConfig_var(rs, 25, "descstr2", "storage_2", false),
+				Config: testAccCheckPacketVolumeConfig_var(rs, 106, "descstr2", "storage_2", false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketVolumeExists("packet_volume.foobar", &v4),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
pre-sweeper run in acceptance tests is failing because of residual volumes

This PR adds sweeper for volumes.