### PR TITLE
Add sweepers for Organizations

### DIFF
--- a/packet/datasource_packet_organization_test.go
+++ b/packet/datasource_packet_organization_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/packethost/packngo"
 )
 
 func TestAccOrgDataSource_Basic(t *testing.T) {
 	var org packngo.Organization
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,15 +19,17 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckPacketOrgDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketOrgDataSourceConfigBasic,
+				Config: testAccCheckPacketOrgDataSourceConfigBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
 					resource.TestCheckResourceAttr(
-						"packet_organization.test", "name", "tfacc-datasource-org"),
+						"packet_organization.test", "name",
+						fmt.Sprintf("tfacc-datasource-org-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "description", "quux"),
 					resource.TestCheckResourceAttr(
-						"data.packet_organization.test", "name", "tfacc-datasource-org"),
+						"data.packet_organization.test", "name",
+						fmt.Sprintf("tfacc-datasource-org-%d", rInt)),
 					resource.TestCheckResourceAttrPair(
 						"data.packet_organization.test2", "id", "packet_organization.test", "id"),
 				),
@@ -34,9 +38,10 @@ func TestAccOrgDataSource_Basic(t *testing.T) {
 	})
 }
 
-var testAccCheckPacketOrgDataSourceConfigBasic = fmt.Sprintf(`
+func testAccCheckPacketOrgDataSourceConfigBasic(r int) string {
+	return fmt.Sprintf(`
 resource "packet_organization" "test" {
-		name = "tfacc-datasource-org"
+		name = "tfacc-datasource-org-%d"
 		description = "quux"
 }
 
@@ -48,4 +53,5 @@ data "packet_organization" "test2" {
     name = "${packet_organization.test.name}"
 }
 
-`)
+`, r)
+}

--- a/packet/resource_packet_organization_test.go
+++ b/packet/resource_packet_organization_test.go
@@ -2,15 +2,55 @@ package packet
 
 import (
 	"fmt"
+	"log"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/packethost/packngo"
 )
 
+func init() {
+	resource.AddTestSweepers("packet_organization", &resource.Sweeper{
+		Name:         "packet_organization",
+		Dependencies: []string{"packet_project"},
+		F:            testSweepOrganizations,
+	})
+}
+
+func testSweepOrganizations(region string) error {
+	log.Printf("[DEBUG] Sweeping organizations")
+	meta, err := sharedConfigForRegion(region)
+	if err != nil {
+		return fmt.Errorf("Error getting client for sweeping organizations: %s", err)
+	}
+	client := meta.(*packngo.Client)
+
+	os, _, err := client.Organizations.List(nil)
+	if err != nil {
+		return fmt.Errorf("Error getting org list for sweepeing organizations: %s", err)
+	}
+	oids := []string{}
+	for _, o := range os {
+		if strings.HasPrefix(o.Name, "tfacc-") {
+			oids = append(oids, o.ID)
+		}
+	}
+	for _, oid := range oids {
+		log.Printf("Removing organization %s", oid)
+		_, err := client.Organizations.Delete(oid)
+		if err != nil {
+			return fmt.Errorf("Error deleting organization %s", err)
+		}
+	}
+	return nil
+}
+
 func TestAccOrgCreate(t *testing.T) {
 	var org packngo.Organization
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,11 +58,11 @@ func TestAccOrgCreate(t *testing.T) {
 		CheckDestroy: testAccCheckPacketOrgDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketOrgConfigBasic,
+				Config: testAccCheckPacketOrgConfigBasic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketOrgExists("packet_organization.test", &org),
 					resource.TestCheckResourceAttr(
-						"packet_organization.test", "name", "tfacc-org"),
+						"packet_organization.test", "name", fmt.Sprintf("tfacc-org-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"packet_organization.test", "description", "quux"),
 				),
@@ -32,13 +72,14 @@ func TestAccOrgCreate(t *testing.T) {
 }
 
 func TestAccOrg_importBasic(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPacketOrgDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketOrgConfigBasic,
+				Config: testAccCheckPacketOrgConfigBasic(rInt),
 			},
 			{
 				ResourceName:      "packet_organization.test",
@@ -90,8 +131,10 @@ func testAccCheckPacketOrgExists(n string, org *packngo.Organization) resource.T
 	}
 }
 
-var testAccCheckPacketOrgConfigBasic = fmt.Sprintf(`
+func testAccCheckPacketOrgConfigBasic(r int) string {
+	return fmt.Sprintf(`
 resource "packet_organization" "test" {
-		name = "tfacc-org"
+		name = "tfacc-org-%d"
 		description = "quux"
-}`)
+}`, r)
+}


### PR DESCRIPTION
I noticed that there were remnant organizations in the Acceptance test account. This PR adds code to properly sweep them.

It also improved naming of test organizations, to avoid name clash between datasource and resource test for org.