### PR TITLE
device attr ip_address_type from deprecated to removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 - [#225](https://github.com/terraform-providers/terraform-provider-packet/pull/225) Bump packngo to version correctly handling hybrid mode for n2.xlarge device plan
+- [#226](https://github.com/terraform-providers/terraform-provider-packet/pull/226) Remove deprecated code for ip_address_type attribute of the packet_device resource
 
 ## 2.7.5 (February 26, 2020)
 

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -79,7 +79,7 @@ func resourcePacketDevice() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(ipAddressTypes, false),
 				},
-				Removed: "Deprecated in favor of 'ip_address' attribute.",
+				Removed: "Removed in favor of 'ip_address' attribute.",
 			},
 			"facilities": {
 				Type:     schema.TypeList,
@@ -106,7 +106,7 @@ func resourcePacketDevice() *schema.Resource {
 				Description:   "Inbound rules for this security group",
 				Elem:          ipAddressSchema(),
 				MinItems:      1,
-				ConflictsWith: []string{"ip_address_types"},
+				ConflictsWith: []string{"public_ipv4_subnet_size"},
 			},
 
 			"plan": {
@@ -314,27 +314,6 @@ func resourcePacketDevice() *schema.Resource {
 			},
 		},
 	}
-}
-
-func getOldIPAddressSlice(arr []string) []packngo.IPAddressCreateRequest {
-	addressTypesSlice := make([]packngo.IPAddressCreateRequest, len(arr))
-
-	for i, at := range arr {
-		iacr := packngo.IPAddressCreateRequest{}
-		switch at {
-		case "public_ipv4":
-			iacr.AddressFamily = 4
-			iacr.Public = true
-		case "private_ipv4":
-			iacr.AddressFamily = 4
-			iacr.Public = false
-		case "public_ipv6":
-			iacr.AddressFamily = 6
-			iacr.Public = true
-		}
-		addressTypesSlice[i] = iacr
-	}
-	return addressTypesSlice
 }
 
 func ifToIPCreateRequest(m interface{}) packngo.IPAddressCreateRequest {

--- a/packet/resource_packet_device.go
+++ b/packet/resource_packet_device.go
@@ -74,16 +74,12 @@ func resourcePacketDevice() *schema.Resource {
 			},
 			"ip_address_types": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice(ipAddressTypes, false),
 				},
-				MaxItems:      3,
-				MinItems:      1,
-				ForceNew:      true,
-				Deprecated:    "Deprecated in favor of 'ip_address' attribute.",
-				ConflictsWith: []string{"ip_address"},
+				Removed: "Deprecated in favor of 'ip_address' attribute.",
 			},
 			"facilities": {
 				Type:     schema.TypeList,
@@ -246,10 +242,12 @@ func resourcePacketDevice() *schema.Resource {
 			},
 
 			"public_ipv4_subnet_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeInt,
+				Computed:      true,
+				Optional:      true,
+				ForceNew:      true,
+				Deprecated:    "Deprecated in favor of 'ip_address' attribute.",
+				ConflictsWith: []string{"ip_address"},
 			},
 
 			"ipxe_script_url": {
@@ -388,9 +386,6 @@ func resourcePacketDeviceCreate(d *schema.ResourceData, meta interface{}) error 
 	if ok {
 		arr := d.Get("ip_address").([]interface{})
 		addressTypesSlice = getNewIPAddressSlice(arr)
-	} else {
-		arr := convertStringArr(d.Get("ip_address_types").(*schema.Set).List())
-		addressTypesSlice = getOldIPAddressSlice(arr)
 	}
 
 	createRequest := &packngo.DeviceCreateRequest{

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -156,8 +156,8 @@ resource "packet_project" "test" {
 
 resource "packet_device" "test" {
   hostname         = "tfacc-device-hybrid-test"
-  plan             = "s1.large.x86"
-  facilities       = ["nrt1"]
+  plan             = "n2.xlarge.x86"
+  facilities       = ["dfw2"]
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
@@ -166,7 +166,7 @@ resource "packet_device" "test" {
 
 resource "packet_vlan" "test" {
   description = "test vlan"
-  facility    = "nrt1"
+  facility    = "dfw2"
   project_id  = "${packet_project.test.id}"
 }
 

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -161,7 +161,6 @@ The following arguments are supported:
 * `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][https://www.terraform.io/docs/providers/packet/r/project_ssh_key.html] resource.
 * `network_type` (Optional) - Network type of device, used for [Layer 2 networking](https://www.packet.com/developers/docs/network/advanced/layer-2/). Allowed values are `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`. If you keep it empty, Terraform will not handle the network type of the device.
 * `ip_address` (Optional) - A list of IP address types for the device (structure is documented below). 
-* `ip_address_types` (Deprecated) - A set containing one or more of [`private_ipv4`, `public_ipv4`, `public_ipv6`]. It specifies which IP address types a new device should obtain. If omitted, a created device will obtain all 3 addresses. If you only want private IPv4 address for the new device, pass [`private_ipv4`].
 * `wait_for_reservation_deprovision` (Optional) - Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
 * `force_detach_volumes` (Optional) - Delete device even if it has volumes attached. Only applies for destroy action.
 

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 * `plan` - (Required) The device plan slug. To find the plan slug, visit [Device plans API docs](https://www.packet.com/developers/api/plans), set your auth token in the top of the page and see JSON from the API response.
 * `billing_cycle` - (Required) monthly or hourly
 * `user_data` (Optional) - A string of the desired User Data for the device.
-* `public_ipv4_subnet_size` (Optional) - Size of allocated subnet, more
+* `public_ipv4_subnet_size` (Deprecated) - Size of allocated subnet, more
   information is in the
   [Custom Subnet Size](https://www.packet.com/developers/docs/servers/key-features/custom-subnet-size/) doc.
 * `ipxe_script_url` (Optional) - URL pointing to a hosted iPXE script. More

--- a/website/docs/r/port_vlan_attachment.html.markdown
+++ b/website/docs/r/port_vlan_attachment.html.markdown
@@ -15,6 +15,7 @@ Device and VLAN must be in the same facility.
 If you need this resource to add the port back to bond on removal, set `force_bond = true`.
 
 To learn more about Layer 2 networking in Packet, refer to
+
 * https://www.packet.com/resources/guides/layer-2-configurations/ 
 * https://www.packet.com/developers/docs/network/advanced/layer-2/
 


### PR DESCRIPTION
Due process for removal of ip_address_type and the subnet size attrs.

Both are replaced with ip_address attribute.