### PR TITLE
fix conversion from nil during WaitForState loops

### DIFF
--- a/packet/helpers_device.go
+++ b/packet/helpers_device.go
@@ -187,9 +187,14 @@ func waitForDeviceAttribute(d *schema.ResourceData, targets []string, pending []
 		Delay:      10 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
-	attrval, err := stateConf.WaitForState()
 
-	return attrval.(string), err
+	attrValRaw, err := stateConf.WaitForState()
+
+	if v, ok := attrValRaw.(string); ok {
+		return v, err
+	}
+
+	return "", err
 }
 
 // powerOnAndWait Powers on the device and waits for it to be active.


### PR DESCRIPTION
As [reported in Slack](https://packetcommunity.slack.com/archives/CU7HC3RJP/p1594207906242100), `nil` responses were being converted to `string`, causing the following
error pattern:

```
[DEBUG] GET https://api.packet.net/devices/{uuid}?include=project,facility
[TRACE] Waiting 10s before next try
[WARN] WaitForState timeout after 1h0m0s
[WARN] WaitForState starting 30s refresh grace period

panic: interface conversion:
interface {} is nil, not string
```

---

*The terraform-plugin-sdk code triggering this seems related ([based on EC2 comments](https://github.com/hashicorp/terraform-plugin-sdk/blob/master/helper/resource/state.go#L16)) to the AWS provider, which has [evolved the pattern](https://github.com/terraform-providers/terraform-provider-aws/blob/711107a93685d175c3a00dbee50ac5ee26d8c085/aws/internal/service/workspaces/waiter/waiter.go#L83-L89).*