### PR TITLE
Add new resource for Device Network Mode

### DIFF
--- a/packet/provider.go
+++ b/packet/provider.go
@@ -36,6 +36,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"packet_device":               resourcePacketDevice(),
+			"packet_device_network_type":  resourcePacketDeviceNetworkType(),
 			"packet_ssh_key":              resourcePacketSSHKey(),
 			"packet_project_ssh_key":      resourcePacketProjectSSHKey(),
 			"packet_project":              resourcePacketProject(),

--- a/packet/resource_packet_device_network_type.go
+++ b/packet/resource_packet_device_network_type.go
@@ -1,0 +1,105 @@
+package packet
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/packethost/packngo"
+)
+
+func resourcePacketDeviceNetworkType() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePacketDeviceNetworkTypeCreate,
+		Read:   resourcePacketDeviceNetworkTypeRead,
+		Delete: resourcePacketDeviceNetworkTypeDelete,
+		Update: resourcePacketDeviceNetworkTypeUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"layer3", "layer2-bonded", "layer2-individual", "hybrid"}, false),
+			},
+		},
+	}
+}
+
+func getDevIDandNetworkType(d *schema.ResourceData, c *packngo.Client) (string, string, error) {
+	deviceID := d.Id()
+	if len(deviceID) == 0 {
+		deviceID = d.Get("device_id").(string)
+	}
+
+	dev, _, err := c.Devices.Get(deviceID, nil)
+	if err != nil {
+		return "", "", err
+	}
+	devType, err := dev.GetNetworkType()
+	if err != nil {
+		return "", "", err
+	}
+	return dev.ID, devType, nil
+}
+
+func getAndPossiblySetNetworkType(d *schema.ResourceData, c *packngo.Client, targetType string) error {
+	devID, devType, err := getDevIDandNetworkType(d, c)
+	if err != nil {
+		return err
+	}
+
+	if devType != targetType {
+		_, err := c.DevicePorts.DeviceToNetworkType(devID, targetType)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resourcePacketDeviceNetworkTypeCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	ntype := d.Get("type").(string)
+
+	err := getAndPossiblySetNetworkType(d, client, ntype)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("device_id").(string))
+	return resourcePacketDeviceNetworkTypeRead(d, meta)
+}
+
+func resourcePacketDeviceNetworkTypeRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+
+	_, devNType, err := getDevIDandNetworkType(d, client)
+	if err != nil {
+		return err
+	}
+
+	d.Set("type", devNType)
+	return nil
+}
+
+func resourcePacketDeviceNetworkTypeUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*packngo.Client)
+	ntype := d.Get("type").(string)
+	if d.HasChange("type") {
+		err := getAndPossiblySetNetworkType(d, client, ntype)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourcePacketDeviceNetworkTypeRead(d, meta)
+}
+
+func resourcePacketDeviceNetworkTypeDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/packet/resource_packet_device_test.go
+++ b/packet/resource_packet_device_test.go
@@ -225,44 +225,6 @@ func TestAccPacketDevice_IPXEScriptUrl(t *testing.T) {
 	})
 }
 
-func testAccCheckPacketDeviceConfig_L2(projSuffix string) string {
-	return fmt.Sprintf(`
-resource "packet_project" "test" {
-    name = "tfacc-project-%s"
-}
-
-resource "packet_device" "test" {
-  hostname         = "tfacc-device-L2-test"
-  plan             = "m1.xlarge.x86"
-  facilities       = ["ewr1"]
-  operating_system = "ubuntu_16_04"
-  billing_cycle    = "hourly"
-  project_id       = "${packet_project.test.id}"
-  network_type     = "layer2-bonded"
-
-}
-`, projSuffix)
-}
-
-func TestAccPacketDevice_L2(t *testing.T) {
-	rs := acctest.RandString(10)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPacketDeviceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckPacketDeviceConfig_L2(rs),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"packet_device.test", "network_type", "layer2-bonded"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccPacketDevice_IPXEConflictingFields(t *testing.T) {
 	var device packngo.Device
 	rs := acctest.RandString(10)

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/packethost/packngo"
 )
 
-func testAccCheckPacketPortVlanAttachmentConfig_L2Bonded(name string) string {
+func testAccCheckPacketPortVlanAttachmentConfig_L2Bonded_1(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
     name = "tfacc-port_vlan_attachment-%s"
@@ -25,8 +25,13 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
-  network_type     = "layer2-bonded"
 }
+`, name)
+}
+
+func testAccCheckPacketPortVlanAttachmentConfig_L2Bonded_2(name string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "packet_vlan" "test1" {
   description = "test VLAN 1"
@@ -40,19 +45,24 @@ resource "packet_vlan" "test2" {
   project_id  = "${packet_project.test.id}"
 }
 
+resource "packet_device_network_type" "test" {
+  device_id = packet_device.test.id
+  type = "layer2-bonded"
+}
+
 resource "packet_port_vlan_attachment" "test1" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test1.vxlan}"
   port_name = "bond0"
 }
 
 resource "packet_port_vlan_attachment" "test2" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test2.vxlan}"
   port_name = "bond0"
 }
 
-`, name)
+`, testAccCheckPacketPortVlanAttachmentConfig_L2Bonded_1(name))
 }
 
 func TestAccPacketPortVlanAttachment_L2Bonded(t *testing.T) {
@@ -65,7 +75,13 @@ func TestAccPacketPortVlanAttachment_L2Bonded(t *testing.T) {
 		CheckDestroy: testAccCheckPacketPortVlanAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Bonded(rs),
+				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Bonded_1(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("packet_device.test", "network_type", "layer3"),
+				),
+			},
+			{
+				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Bonded_2(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"packet_port_vlan_attachment.test1", "port_name", "bond0"),
@@ -74,13 +90,14 @@ func TestAccPacketPortVlanAttachment_L2Bonded(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"packet_port_vlan_attachment.test1", "device_id",
 						"packet_device.test", "id"),
+					resource.TestCheckResourceAttr("packet_device_network_type.test", "type", "layer2-bonded"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckPacketPortVlanAttachmentConfig_L2Individual(name string) string {
+func testAccCheckPacketPortVlanAttachmentConfig_L2Individual_1(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
     name = "tfacc-port_vlan_attachment-%s"
@@ -93,8 +110,13 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
-  network_type     = "layer2-individual"
 }
+`, name)
+}
+
+func testAccCheckPacketPortVlanAttachmentConfig_L2Individual_2(name string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "packet_vlan" "test1" {
   description = "test VLAN 1"
@@ -108,19 +130,24 @@ resource "packet_vlan" "test2" {
   project_id  = "${packet_project.test.id}"
 }
 
+resource "packet_device_network_type" "test" {
+  device_id = packet_device.test.id
+  type = "layer2-individual"
+}
+
 resource "packet_port_vlan_attachment" "test1" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test1.vxlan}"
   port_name = "eth1"
 }
 
 resource "packet_port_vlan_attachment" "test2" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test2.vxlan}"
   port_name = "eth1"
 }
 
-`, name)
+`, testAccCheckPacketPortVlanAttachmentConfig_L2Individual_1(name))
 }
 
 func TestAccPacketPortVlanAttachment_L2Individual(t *testing.T) {
@@ -133,7 +160,14 @@ func TestAccPacketPortVlanAttachment_L2Individual(t *testing.T) {
 		CheckDestroy: testAccCheckPacketPortVlanAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Individual(rs),
+				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Individual_1(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"packet_device.test", "network_type", "layer3"),
+				),
+			},
+			{
+				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Individual_2(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"packet_port_vlan_attachment.test1", "port_name", "eth1"),
@@ -142,13 +176,15 @@ func TestAccPacketPortVlanAttachment_L2Individual(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"packet_port_vlan_attachment.test1", "device_id",
 						"packet_device.test", "id"),
+					resource.TestCheckResourceAttr(
+						"packet_device_network_type.test", "type", "layer2-individual"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckPacketPortVlanAttachmentConfig_Hybrid(name string) string {
+func testAccCheckPacketPortVlanAttachmentConfig_Hybrid_1(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
     name = "tfacc-port_vlan_attachment-%s"
@@ -161,7 +197,16 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
-  network_type     = "hybrid"
+}`, name)
+}
+
+func testAccCheckPacketPortVlanAttachmentConfig_Hybrid_2(name string) string {
+	return fmt.Sprintf(`
+%s 
+
+resource "packet_device_network_type" "test" {
+  device_id = packet_device.test.id
+  type = "hybrid"
 }
 
 resource "packet_vlan" "test" {
@@ -171,11 +216,11 @@ resource "packet_vlan" "test" {
 }
 
 resource "packet_port_vlan_attachment" "test" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test.vxlan}"
   port_name = "eth1"
   force_bond = false
-}`, name)
+}`, testAccCheckPacketPortVlanAttachmentConfig_Hybrid_1(name))
 }
 
 func TestAccPacketPortVlanAttachment_HybridBasic(t *testing.T) {
@@ -187,7 +232,7 @@ func TestAccPacketPortVlanAttachment_HybridBasic(t *testing.T) {
 		CheckDestroy: testAccCheckPacketPortVlanAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketPortVlanAttachmentConfig_Hybrid(rs),
+				Config: testAccCheckPacketPortVlanAttachmentConfig_Hybrid_1(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"packet_port_vlan_attachment.test", "port_name", "eth1"),
@@ -213,7 +258,6 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = packet_project.test.id
-  network_type     = "hybrid"
 }
 
 resource "packet_vlan" "test" {
@@ -223,9 +267,14 @@ resource "packet_vlan" "test" {
   project_id  = packet_project.test.id
 }
 
+resource "packet_device_network_type" "test" {
+  device_id = packet_device.test.id
+  type = "hybrid"
+}
+
 resource "packet_port_vlan_attachment" "test" {
   count     = length(packet_vlan.test)
-  device_id = packet_device.test.id
+  device_id = packet_device_network_type.test.id
   vlan_vnid = packet_vlan.test[count.index].vxlan
   port_name = "eth1"
 }`, name)
@@ -309,7 +358,6 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
-  network_type     = "layer2-individual"
 }
 
 resource "packet_vlan" "test1" {
@@ -324,14 +372,19 @@ resource "packet_vlan" "test2" {
   project_id  = "${packet_project.test.id}"
 }
 
+resource "packet_device_network_type" "test" {
+  device_id = packet_device.test.id
+  type = "layer2-individual"
+}
+
 resource "packet_port_vlan_attachment" "test1" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test1.vxlan}"
   port_name = "eth1"
 }
 
 resource "packet_port_vlan_attachment" "test2" {
-  device_id = "${packet_device.test.id}"
+  device_id = packet_device_network_type.test.id
   vlan_vnid = "${packet_vlan.test2.vxlan}"
   native    = true
   port_name = "eth1"

--- a/packet/resource_packet_port_vlan_attachment_test.go
+++ b/packet/resource_packet_port_vlan_attachment_test.go
@@ -235,17 +235,26 @@ func TestAccPacketPortVlanAttachment_HybridBasic(t *testing.T) {
 				Config: testAccCheckPacketPortVlanAttachmentConfig_Hybrid_1(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
+						"packet_device.test", "network_type", "layer3"),
+				),
+			},
+			{
+				Config: testAccCheckPacketPortVlanAttachmentConfig_Hybrid_2(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
 						"packet_port_vlan_attachment.test", "port_name", "eth1"),
 					resource.TestCheckResourceAttrPair(
 						"packet_port_vlan_attachment.test", "device_id",
 						"packet_device.test", "id"),
+					resource.TestCheckResourceAttr(
+						"packet_device_network_type.test", "type", "hybrid"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans(name string) string {
+func testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans_1(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
   name = "tfacc-port_vlan_attachment-%s"
@@ -258,7 +267,12 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = packet_project.test.id
+}`, name)
 }
+
+func testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans_2(name string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "packet_vlan" "test" {
   count       = 3
@@ -277,7 +291,7 @@ resource "packet_port_vlan_attachment" "test" {
   device_id = packet_device_network_type.test.id
   vlan_vnid = packet_vlan.test[count.index].vxlan
   port_name = "eth1"
-}`, name)
+}`, testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans_1(name))
 }
 
 func TestAccPacketPortVlanAttachment_HybridMultipleVlans(t *testing.T) {
@@ -289,7 +303,14 @@ func TestAccPacketPortVlanAttachment_HybridMultipleVlans(t *testing.T) {
 		CheckDestroy: testAccCheckPacketPortVlanAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans(rs),
+				Config: testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans_1(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"packet_device.test", "network_type", "layer3"),
+				),
+			},
+			{
+				Config: testAccCheckPacketPortVlanAttachmentConfig_HybridMultipleVlans_2(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"packet_port_vlan_attachment.test.0", "port_name", "eth1"),
@@ -303,6 +324,8 @@ func TestAccPacketPortVlanAttachment_HybridMultipleVlans(t *testing.T) {
 						"packet_port_vlan_attachment.test.2", "port_name", "eth1"),
 					resource.TestCheckResourceAttrPair(
 						"packet_port_vlan_attachment.test.2", "device_id", "packet_device.test", "id"),
+					resource.TestCheckResourceAttr(
+						"packet_device_network_type.test", "type", "hybrid"),
 				),
 			},
 		},
@@ -345,7 +368,7 @@ func testAccCheckPacketPortVlanAttachmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckPacketPortVlanAttachmentConfig_L2Native(name string) string {
+func testAccCheckPacketPortVlanAttachmentConfig_L2Native_1(name string) string {
 	return fmt.Sprintf(`
 resource "packet_project" "test" {
     name = "tfacc-port_vlan_attachment-%s"
@@ -358,7 +381,12 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = "${packet_project.test.id}"
+}`, name)
 }
+
+func testAccCheckPacketPortVlanAttachmentConfig_L2Native_2(name string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "packet_vlan" "test1" {
   description = "test VLAN 1"
@@ -391,7 +419,7 @@ resource "packet_port_vlan_attachment" "test2" {
   depends_on = ["packet_port_vlan_attachment.test1"]
 }
 
-`, name)
+`, testAccCheckPacketPortVlanAttachmentConfig_L2Native_1(name))
 }
 
 func TestAccPacketPortVlanAttachment_L2Native(t *testing.T) {
@@ -404,7 +432,14 @@ func TestAccPacketPortVlanAttachment_L2Native(t *testing.T) {
 		CheckDestroy: testAccCheckPacketPortVlanAttachmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Native(rs),
+				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Native_1(rs),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"packet_device.test", "network_type", "layer3"),
+				),
+			},
+			{
+				Config: testAccCheckPacketPortVlanAttachmentConfig_L2Native_2(rs),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"packet_port_vlan_attachment.test1", "port_name", "eth1"),
@@ -415,6 +450,8 @@ func TestAccPacketPortVlanAttachment_L2Native(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"packet_port_vlan_attachment.test1", "device_id",
 						"packet_device.test", "id"),
+					resource.TestCheckResourceAttr(
+						"packet_device_network_type.test", "type", "layer2-individual"),
 				),
 			},
 		},

--- a/website/docs/r/device.html.markdown
+++ b/website/docs/r/device.html.markdown
@@ -157,7 +157,6 @@ The following arguments are supported:
 * `tags` - Tags attached to the device
 * `description` - Description string for the device
 * `project_ssh_key_ids` - Array of IDs of the project SSH keys which should be added to the device. If you omit this, SSH keys of all the members of the parent project will be added to the device. If you specify this array, only the listed project SSH keys will be added. Project SSH keys can be created with the [packet_project_ssh_key][https://www.terraform.io/docs/providers/packet/r/project_ssh_key.html] resource.
-* `network_type` (Optional) - Network type of device, used for [Layer 2 networking](https://www.packet.com/developers/docs/network/advanced/layer-2/). Allowed values are `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`. If you keep it empty, Terraform will not handle the network type of the device.
 * `ip_address` (Optional) - A list of IP address types for the device (structure is documented below). 
 * `wait_for_reservation_deprovision` (Optional) - Only used for devices in reserved hardware. If set, the deletion of this device will block until the hardware reservation is marked provisionable (about 4 minutes in August 2019).
 * `force_detach_volumes` (Optional) - Delete device even if it has volumes attached. Only applies for destroy action.
@@ -198,6 +197,7 @@ The following attributes are exported:
   * `gateway` - address of router
   * `public` - whether the address is routable from the Internet
   * `family` - IP version - "4" or "6"
+* `network_mode` Network mode of a device, used in [Layer 2 networking](https://www.packet.com/developers/docs/network/advanced/layer-2/). Will be one of `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`.
 * `operating_system` - The operating system running on the device
 * `plan` - The hardware config of the device
 * `ports` - Ports assigned to the device

--- a/website/docs/r/device_network_type.markdown
+++ b/website/docs/r/device_network_type.markdown
@@ -1,0 +1,59 @@
+---
+layout: "packet"
+page_title: "Packet: packet_device_network_type"
+sidebar_current: "docs-packet-resource-device-network-type"
+description: |-
+  Provides a resource to manage network type of Packet devices.
+---
+
+# packet_device_network_type
+
+This resource controls network type of Packet devices.
+
+To learn more about Layer 2 networking in Packet, refer to
+
+* https://www.packet.com/resources/guides/layer-2-configurations/
+* https://www.packet.com/developers/docs/network/advanced/layer-2/
+
+## Example Usage
+
+```
+resource "packet_device" "test" {
+  hostname         = "tfacc-device-port-vlan-attachment-test"
+  plan             = "s1.large.x86"
+  facilities       = ["nrt1"]
+  operating_system = "ubuntu_16_04"
+  billing_cycle    = "hourly"
+  project_id       = local.project_id
+}
+
+resource "packet_device_network_type" "test" {
+  device_id = packet_device.test.id
+  type = "hybrid"
+}
+```
+
+If you are attaching VLAN to a device (i.e. using packet_port_vlan_attachment), link the device ID from this resource, in order to make the port attachment implicitly dependent on the state of the network type. If you link the device ID from the packet_device resource, Terraform will not wait for the network type change. See examples in [packet_port_vlan_attachment](port_vlan_attachment.html).
+
+
+## Import
+
+This resource can also be imported using existing device ID:
+
+```
+$ terraform import packet_device_network_type {existing device_id}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `device_id` - (Required) The ID of the device on which the network type should be set.
+* `type` - (Required) Network type to set. Must be one of `layer3`, `hybrid`, `layer2-individual` and `layer2-bonded`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - ID of the controlled device. Use this in linked resources, if you need to wait for the network type change. It is the same as `device_id`.

--- a/website/docs/r/port_vlan_attachment.html.markdown
+++ b/website/docs/r/port_vlan_attachment.html.markdown
@@ -37,11 +37,15 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
-  network_type     = "hybrid"
+}
+
+resource "packet_device_network_mode" "test" {
+  device_id = packet_device.test.id
+  mode = "hybrid"
 }
 
 resource "packet_port_vlan_attachment" "test" {
-  device_id = packet_device.test.id
+  device_id = packet_device_network_mode.test.id
   port_name = "eth1"
   vlan_vnid = packet_vlan.test.vxlan
 }
@@ -56,7 +60,11 @@ resource "packet_device" "test" {
   operating_system = "ubuntu_16_04"
   billing_cycle    = "hourly"
   project_id       = local.project_id
-  network_type     = "layer2-individual"
+}
+
+resource "packet_device_network_mode" "test" {
+  device_id = packet_device.test.id
+  mode = "layer2-individual"
 }
 
 resource "packet_vlan" "test1" {
@@ -72,13 +80,13 @@ resource "packet_vlan" "test2" {
 }
 
 resource "packet_port_vlan_attachment" "test1" {
-  device_id = packet_device.test.id
+  device_id = packet_device_network_mode.test.id
   vlan_vnid = packet_vlan.test1.vxlan
   port_name = "eth1"
 }
 
 resource "packet_port_vlan_attachment" "test2" {
-  device_id  = packet_device.test.id
+  device_id  = packet_device_network_mode.test.id
   vlan_vnid  = packet_vlan.test2.vxlan
   port_name  = "eth1"
   native     = true

--- a/website/packet.erb
+++ b/website/packet.erb
@@ -56,6 +56,9 @@
             <li<%= sidebar_current("docs-packet-resource-device") %>>
               <a href="/docs/providers/packet/r/device.html">packet_device</a>
             </li>
+           <li<%= sidebar_current("docs-packet-resource-device-network-type") %>>
+             <a href="/docs/providers/packet/r/device_network_type.html">packet_device_network_type</a>
+           </li>
             <li<%= sidebar_current("docs-packet-resource-ip-attachment") %>>
               <a href="/docs/providers/packet/r/ip_attachment.html">packet_ip_attachment</a>
             </li>


### PR DESCRIPTION
This PR decouples the Network Mode handling from the device resource. We've had a lot of issues with the network mode reading, setting and waiting for it. If the API calls fails, it's better if it's in a separate resource, because some devices have very long provisioning times and re-creating of fixing TF state becomes really ugly.

Relevant issues:
* The network mode handling created a lot issues in Packet Anthos: https://github.com/packet-labs/google-anthos/issues/25#issuecomment-656471472
* https://github.com/terraform-providers/terraform-provider-packet/issues/238 Good old network state API cache issue - network state of a device is changed, but the /device/\<uuid\> endpoint is cached and doesn't update, so TF hangs. Third time it's resurrected.
* same as above but reported in packngo, as an API issue: https://github.com/packethost/packngo/issues/133

The new usage will then look as:

```
resource "packet_vlan" "test" {
  description = "VLAN in New Jersey"
  facility    = "ewr1"
  project_id  = local.project_id
}

resource "packet_device" "test" {
  hostname         = "test"
  plan             = "m1.xlarge.x86"
  facilities       = ["ewr1"]
  operating_system = "ubuntu_16_04"
  billing_cycle    = "hourly"
  project_id       = local.project_id
}

// THIS IS NEW vvvvvvvvvvvvvvvvvvvvvvvvv
resource "packet_device_network_mode" "test" {
  device_id = packet_device.test.id
  mode = "hybrid"
}

resource "packet_port_vlan_attachment" "test" {
// LINK DEVICE THROUGH THE NEW RESOURCE vvvvvvvvvv
  device_id = packet_device_network_mode.test.id
  port_name = "eth1"
  vlan_vnid = packet_vlan.test.vxlan
}

```

Note that the `packet_port_vlan_attachment` must depend on `packet_device_network_mode`, not on `packet_device`, so that TF waits for the network mode change.

I also added a `http_get_excludes` param, which can be used to fool the Packet API cache and maybe workaround the bug. If TF hangs on the state change, try to add `project_lite` to the excludes, and it might just avoid the cache hit:

```
resource "packet_device_network_mode" "test" {
  device_id = packet_device.test.id
  mode = "hybrid"
  http_get_excludes = ["project_lite"]
}

```